### PR TITLE
fix(terminal): use platform-appropriate command syntax on Windows

### DIFF
--- a/packages/domains/terminal/src/main/adapters/codex-adapter.test.ts
+++ b/packages/domains/terminal/src/main/adapters/codex-adapter.test.ts
@@ -67,19 +67,29 @@ test('detects alternative working indicator phrases', () => {
 
 console.log('\nCodexAdapter.buildSpawnConfig\n')
 
+const isWin = process.platform === 'win32'
+
 test('starts fresh codex session by default', () => {
   const result = adapter.buildSpawnConfig('/tmp')
-  expect(result.postSpawnCommand).toBe("exec 'codex'")
+  expect(result.postSpawnCommand).toBe(isWin ? 'codex' : "exec 'codex'")
 })
 
 test('resumes codex session when existing conversation ID is provided', () => {
   const result = adapter.buildSpawnConfig('/tmp', '11111111-2222-4333-8444-555555555555', true)
-  expect(result.postSpawnCommand).toBe("exec 'codex' 'resume' '11111111-2222-4333-8444-555555555555'")
+  expect(result.postSpawnCommand).toBe(
+    isWin
+      ? 'codex resume 11111111-2222-4333-8444-555555555555'
+      : "exec 'codex' 'resume' '11111111-2222-4333-8444-555555555555'"
+  )
 })
 
 test('includes provider flags while resuming', () => {
   const result = adapter.buildSpawnConfig('/tmp', 'thread-123', true, undefined, ['--search'])
-  expect(result.postSpawnCommand).toBe("exec 'codex' 'resume' 'thread-123' '--search'")
+  expect(result.postSpawnCommand).toBe(
+    isWin
+      ? 'codex resume thread-123 --search'
+      : "exec 'codex' 'resume' 'thread-123' '--search'"
+  )
 })
 
 console.log('\nCodexAdapter.detectError\n')

--- a/packages/domains/terminal/src/main/shell-env.ts
+++ b/packages/domains/terminal/src/main/shell-env.ts
@@ -87,12 +87,18 @@ export function getShellStartupArgs(shellPath: string): string[] {
 }
 
 export function quoteForShell(arg: string): string {
+  if (platform() === 'win32') {
+    if (arg.length === 0) return '""'
+    if (!/[\s"&|<>^%!]/.test(arg)) return arg
+    return `"${arg.replace(/"/g, '""')}"`
+  }
   if (arg.length === 0) return "''"
   return `'${arg.replace(/'/g, `'"'"'`)}'`
 }
 
 export function buildExecCommand(binary: string, args: string[] = []): string {
   const escaped = [binary, ...args].map(quoteForShell).join(' ')
+  if (platform() === 'win32') return escaped
   return `exec ${escaped}`
 }
 


### PR DESCRIPTION
## Summary

Fixes #1 — On Windows, all AI CLI launches (Claude Code, Codex, Cursor Agent, Gemini, OpenCode) fail with `'exec' is not recognized` because `exec` is a Unix shell builtin that doesn't exist in `cmd.exe`.

A secondary issue: `cmd.exe` uses double quotes for argument escaping, not single quotes. So even without `exec`, a command like `'claude'` (single-quoted) would fail in `cmd.exe` since single quotes are treated as literal characters.

## Changes

Both changes are in `packages/domains/terminal/src/main/shell-env.ts`:

### `buildExecCommand` — skip `exec` on Windows
- On Unix, `exec` replaces the shell process with the spawned CLI (saves a process). This is a shell builtin that doesn't exist on Windows.
- On `win32`, the function now returns the command without the `exec` prefix.
- All 6 adapters (claude, codex, cursor, gemini, opencode, shell) benefit from this fix since they all call `buildExecCommand`.

### `quoteForShell` — use `cmd.exe`-compatible quoting on Windows
- On Unix: single-quote wrapping with `'"'"'` escape (unchanged)
- On `win32`: no quotes for simple args, double-quote wrapping with `""` escape for args containing special characters (`\s"&|<>^%!`)

### Test updates
- `codex-adapter.test.ts` — `buildSpawnConfig` expectations are now platform-aware, verifying correct output on both Windows and Unix.

## How it was tested

- Codex adapter tests pass on Windows: all 13 assertions green
- Unix behavior is unchanged (the new branches only activate when `os.platform() === 'win32'`)

## Test plan
- [ ] Launch Claude Code task on Windows — should no longer show `'exec' is not recognized`
- [ ] Launch Codex task on Windows
- [ ] Verify Mac/Linux still works (no behavior change on non-win32 platforms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)