### PR TITLE
feat(projects/tasks): add db vs repository task storage with docs/tasks json sync

### DIFF
--- a/packages/apps/app/e2e/fixtures/electron.ts
+++ b/packages/apps/app/e2e/fixtures/electron.ts
@@ -325,7 +325,12 @@ export const test = base.extend<ElectronFixtures>({
 /** Seed helpers — call window.api methods to create test data without UI interaction */
 export function seed(page: Page) {
   return {
-    createProject: (data: { name: string; color: string; path?: string }) =>
+    createProject: (data: {
+      name: string
+      color: string
+      path?: string
+      taskStorage?: 'database' | 'repository'
+    }) =>
       page.evaluate((d) => window.api.db.createProject(d), data),
 
     createTask: (data: {

--- a/packages/apps/app/src/main/db/migrations.ts
+++ b/packages/apps/app/src/main/db/migrations.ts
@@ -716,6 +716,15 @@ const migrations: Migration[] = [
     up: (db) => {
       db.exec(`DROP TABLE IF EXISTS diagnostics_events`)
     }
+  },
+  {
+    version: 42,
+    up: (db) => {
+      db.exec(`
+        ALTER TABLE projects
+          ADD COLUMN task_storage TEXT NOT NULL DEFAULT 'database';
+      `)
+    }
   }
 ]
 

--- a/packages/apps/app/src/preload/index.ts
+++ b/packages/apps/app/src/preload/index.ts
@@ -30,6 +30,7 @@ const api: ElectronAPI = {
     getTasksByProject: (projectId) => ipcRenderer.invoke('db:tasks:getByProject', projectId),
     getTask: (id) => ipcRenderer.invoke('db:tasks:get', id),
     getSubTasks: (parentId) => ipcRenderer.invoke('db:tasks:getSubTasks', parentId),
+    syncTasksFromProject: (projectId) => ipcRenderer.invoke('db:tasks:syncFromProject', projectId),
     createTask: (data) => ipcRenderer.invoke('db:tasks:create', data),
     updateTask: (data) => ipcRenderer.invoke('db:tasks:update', data),
     deleteTask: (id) => ipcRenderer.invoke('db:tasks:delete', id),

--- a/packages/apps/app/src/renderer/src/lib/schemas.ts
+++ b/packages/apps/app/src/renderer/src/lib/schemas.ts
@@ -31,7 +31,8 @@ export const updateTaskSchema = z.object({
 // Project creation schema
 export const createProjectSchema = z.object({
   name: z.string().min(1, 'Name required').max(100, 'Name too long'),
-  color: z.string().regex(/^#[0-9a-fA-F]{6}$/, 'Invalid hex color')
+  color: z.string().regex(/^#[0-9a-fA-F]{6}$/, 'Invalid hex color'),
+  taskStorage: z.enum(['database', 'repository']).optional()
 })
 
 // Project update schema
@@ -41,7 +42,8 @@ export const updateProjectSchema = z.object({
   color: z
     .string()
     .regex(/^#[0-9a-fA-F]{6}$/)
-    .optional()
+    .optional(),
+  taskStorage: z.enum(['database', 'repository']).optional()
 })
 
 // Form data types - explicit for forms

--- a/packages/domains/projects/src/client/CreateProjectDialog.tsx
+++ b/packages/domains/projects/src/client/CreateProjectDialog.tsx
@@ -5,7 +5,8 @@ import { Button } from '@slayzone/ui'
 import { Input } from '@slayzone/ui'
 import { Label } from '@slayzone/ui'
 import { ColorPicker } from '@slayzone/ui'
-import type { Project } from '@slayzone/projects/shared'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@slayzone/ui'
+import type { Project, ProjectTaskStorage } from '@slayzone/projects/shared'
 
 interface CreateProjectDialogProps {
   open: boolean
@@ -19,6 +20,7 @@ export function CreateProjectDialog({ open, onOpenChange, onCreated }: CreatePro
   const [name, setName] = useState('')
   const [color, setColor] = useState(() => DEFAULT_COLORS[Math.floor(Math.random() * DEFAULT_COLORS.length)])
   const [path, setPath] = useState('')
+  const [taskStorage, setTaskStorage] = useState<ProjectTaskStorage>('database')
   const [loading, setLoading] = useState(false)
 
   const handleBrowse = async () => {
@@ -45,11 +47,18 @@ export function CreateProjectDialog({ open, onOpenChange, onCreated }: CreatePro
       const project = await window.api.db.createProject({
         name: name.trim(),
         color,
-        path: path || undefined
+        path: path || undefined,
+        taskStorage
       })
+      if (taskStorage === 'repository' && path) {
+        await window.api.db.syncTasksFromProject(project.id)
+        const refreshData = (window as { __slayzone_refreshData?: () => void }).__slayzone_refreshData
+        refreshData?.()
+      }
       onCreated(project)
       setName('')
       setPath('')
+      setTaskStorage('database')
       setColor(DEFAULT_COLORS[Math.floor(Math.random() * DEFAULT_COLORS.length)])
     } finally {
       setLoading(false)
@@ -92,6 +101,21 @@ export function CreateProjectDialog({ open, onOpenChange, onCreated }: CreatePro
             </p>
           </div>
           <div className="space-y-2">
+            <Label htmlFor="task-storage">Task Storage</Label>
+            <Select value={taskStorage} onValueChange={(value) => setTaskStorage(value as ProjectTaskStorage)}>
+              <SelectTrigger id="task-storage">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="database">Database (SQLite)</SelectItem>
+                <SelectItem value="repository">Repository (`docs/tasks/*.json`)</SelectItem>
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground">
+              Repository mode reads and writes task files in <code>docs/tasks</code>.
+            </p>
+          </div>
+          <div className="space-y-2">
             <Label>Color</Label>
             <ColorPicker value={color} onChange={setColor} />
           </div>
@@ -99,7 +123,10 @@ export function CreateProjectDialog({ open, onOpenChange, onCreated }: CreatePro
             <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
               Cancel
             </Button>
-            <Button type="submit" disabled={!name.trim() || loading}>
+            <Button
+              type="submit"
+              disabled={!name.trim() || loading || (taskStorage === 'repository' && !path.trim())}
+            >
               Create
             </Button>
           </div>

--- a/packages/domains/projects/src/main/handlers.test.ts
+++ b/packages/domains/projects/src/main/handlers.test.ts
@@ -10,16 +10,33 @@ registerProjectHandlers(h.ipcMain as never, h.db)
 
 describe('db:projects:create', () => {
   test('creates with defaults', () => {
-    const p = h.invoke('db:projects:create', { name: 'Alpha', color: '#ff0000' }) as { id: string; name: string; color: string; path: null }
+    const p = h.invoke('db:projects:create', { name: 'Alpha', color: '#ff0000' }) as {
+      id: string
+      name: string
+      color: string
+      path: null
+      task_storage: string
+    }
     expect(p.name).toBe('Alpha')
     expect(p.color).toBe('#ff0000')
     expect(p.path).toBeNull()
+    expect(p.task_storage).toBe('database')
     expect(p.id).toBeTruthy()
   })
 
   test('creates with path', () => {
     const p = h.invoke('db:projects:create', { name: 'Beta', color: '#00f', path: '/tmp/beta' }) as { path: string }
     expect(p.path).toBe('/tmp/beta')
+  })
+
+  test('creates with repository task storage', () => {
+    const p = h.invoke('db:projects:create', {
+      name: 'Repo',
+      color: '#0f0',
+      path: '/tmp/repo',
+      taskStorage: 'repository'
+    }) as { task_storage: string }
+    expect(p.task_storage).toBe('repository')
   })
 })
 
@@ -61,6 +78,14 @@ describe('db:projects:update', () => {
     const gamma = all.find(p => p.name === 'Gamma')!
     const p = h.invoke('db:projects:update', { id: gamma.id }) as { name: string }
     expect(p.name).toBe('Gamma')
+  })
+
+  test('updates task storage mode', () => {
+    const all = h.invoke('db:projects:getAll') as { id: string }[]
+    const p = h.invoke('db:projects:update', { id: all[0].id, taskStorage: 'repository' }) as {
+      task_storage: string
+    }
+    expect(p.task_storage).toBe('repository')
   })
 })
 

--- a/packages/domains/projects/src/main/handlers.ts
+++ b/packages/domains/projects/src/main/handlers.ts
@@ -11,10 +11,10 @@ export function registerProjectHandlers(ipcMain: IpcMain, db: Database): void {
   ipcMain.handle('db:projects:create', (_, data: CreateProjectInput) => {
     const id = crypto.randomUUID()
     const stmt = db.prepare(`
-      INSERT INTO projects (id, name, color, path)
-      VALUES (?, ?, ?, ?)
+      INSERT INTO projects (id, name, color, path, task_storage)
+      VALUES (?, ?, ?, ?, ?)
     `)
-    stmt.run(id, data.name, data.color, data.path ?? null)
+    stmt.run(id, data.name, data.color, data.path ?? null, data.taskStorage ?? 'database')
     return db.prepare('SELECT * FROM projects WHERE id = ?').get(id)
   })
 
@@ -33,6 +33,10 @@ export function registerProjectHandlers(ipcMain: IpcMain, db: Database): void {
     if (data.path !== undefined) {
       fields.push('path = ?')
       values.push(data.path)
+    }
+    if (data.taskStorage !== undefined) {
+      fields.push('task_storage = ?')
+      values.push(data.taskStorage)
     }
     if (data.autoCreateWorktreeOnTaskCreate !== undefined) {
       fields.push('auto_create_worktree_on_task_create = ?')

--- a/packages/domains/projects/src/shared/types.ts
+++ b/packages/domains/projects/src/shared/types.ts
@@ -1,8 +1,11 @@
+export type ProjectTaskStorage = 'database' | 'repository'
+
 export interface Project {
   id: string
   name: string
   color: string
   path: string | null
+  task_storage: ProjectTaskStorage
   auto_create_worktree_on_task_create: number | null
   created_at: string
   updated_at: string
@@ -12,6 +15,7 @@ export interface CreateProjectInput {
   name: string
   color: string
   path?: string
+  taskStorage?: ProjectTaskStorage
 }
 
 export interface UpdateProjectInput {
@@ -19,5 +23,6 @@ export interface UpdateProjectInput {
   name?: string
   color?: string
   path?: string | null
+  taskStorage?: ProjectTaskStorage
   autoCreateWorktreeOnTaskCreate?: boolean | null
 }

--- a/packages/domains/task/src/main/handlers.test.ts
+++ b/packages/domains/task/src/main/handlers.test.ts
@@ -5,13 +5,17 @@
 import { createTestHarness, test, expect, describe } from '../../../../shared/test-utils/ipc-harness.js'
 import { registerTaskHandlers, updateTask } from './handlers.js'
 import type { Task, ProviderConfig } from '../shared/types.js'
+import fs from 'fs'
+import path from 'path'
 
 const h = await createTestHarness()
 registerTaskHandlers(h.ipcMain as never, h.db)
 
 // Seed a project
 const projectId = crypto.randomUUID()
-h.db.prepare('INSERT INTO projects (id, name, color, path) VALUES (?, ?, ?, ?)').run(projectId, 'TestProject', '#000', '/tmp/test')
+const projectPath = h.tmpDir()
+h.db.prepare('INSERT INTO projects (id, name, color, path, task_storage) VALUES (?, ?, ?, ?, ?)')
+  .run(projectId, 'TestProject', '#000', projectPath, 'repository')
 
 // Helper
 function createTask(title: string, extra?: Record<string, unknown>): Task {
@@ -56,6 +60,25 @@ describe('db:tasks:create', () => {
     const child = createTask('Child', { parentId: parent.id })
     expect(child.parent_id).toBe(parent.id)
   })
+
+  test('writes task files to docs/tasks', () => {
+    const t = createTask('File Write')
+    const taskJson = path.join(projectPath, 'docs', 'tasks', `${t.id}.json`)
+    expect(fs.existsSync(taskJson)).toBe(true)
+    const json = JSON.parse(fs.readFileSync(taskJson, 'utf8')) as { id: string; title: string }
+    expect(json.id).toBe(t.id)
+    expect(json.title).toBe('File Write')
+  })
+
+  test('does not write repo files for database storage project', () => {
+    const dbProjectId = crypto.randomUUID()
+    const dbProjectPath = h.tmpDir()
+    h.db.prepare('INSERT INTO projects (id, name, color, path, task_storage) VALUES (?, ?, ?, ?, ?)')
+      .run(dbProjectId, 'DbBacked', '#222', dbProjectPath, 'database')
+    const t = h.invoke('db:tasks:create', { projectId: dbProjectId, title: 'DB only' }) as Task
+    const taskJson = path.join(dbProjectPath, 'docs', 'tasks', `${t.id}.json`)
+    expect(fs.existsSync(taskJson)).toBe(false)
+  })
 })
 
 describe('db:tasks:get', () => {
@@ -84,6 +107,30 @@ describe('db:tasks:getByProject', () => {
       expect(t.project_id).toBe(projectId)
       expect(t.archived_at).toBeNull()
     }
+  })
+
+  test('imports tasks from docs/tasks json', () => {
+    const fileProjectId = crypto.randomUUID()
+    const fileProjectPath = h.tmpDir()
+    h.db.prepare('INSERT INTO projects (id, name, color, path, task_storage) VALUES (?, ?, ?, ?, ?)')
+      .run(fileProjectId, 'FileBacked', '#111', fileProjectPath, 'repository')
+
+    const tasksDir = path.join(fileProjectPath, 'docs', 'tasks')
+    fs.mkdirSync(tasksDir, { recursive: true })
+    fs.writeFileSync(path.join(tasksDir, 'task-from-file.json'), JSON.stringify({
+      id: 'task-from-file',
+      title: 'Task From File',
+      description: 'Description from json',
+      status: 'todo',
+      priority: 2
+    }, null, 2))
+
+    const tasks = h.invoke('db:tasks:getByProject', fileProjectId) as Task[]
+    const imported = tasks.find((task) => task.id === 'task-from-file')
+    expect(imported?.title).toBe('Task From File')
+    expect(imported?.description).toBe('Description from json')
+    expect(imported?.status).toBe('todo')
+    expect(imported?.priority).toBe(2)
   })
 })
 

--- a/packages/domains/task/src/main/handlers.ts
+++ b/packages/domains/task/src/main/handlers.ts
@@ -1,11 +1,16 @@
 import type { IpcMain } from 'electron'
 import type { Database } from 'better-sqlite3'
 import type { CreateTaskInput, UpdateTaskInput, Task, ProviderConfig } from '@slayzone/task/shared'
-import { PROVIDER_DEFAULTS } from '@slayzone/task/shared'
 import { recordDiagnosticEvent } from '@slayzone/diagnostics/main'
 import path from 'path'
 import { removeWorktree, createWorktree, getCurrentBranch, isGitRepo } from '@slayzone/worktrees/main'
 import { killPtysByTaskId } from '@slayzone/terminal/main'
+import {
+  buildDefaultProviderConfig,
+  deleteTaskFromFilesystem,
+  syncProjectTasksFromFilesystem,
+  writeTaskToFilesystem
+} from './task-files'
 
 function safeJsonParse(value: unknown): unknown {
   if (!value || typeof value !== 'string') return null
@@ -43,6 +48,14 @@ function parseTask(row: Record<string, unknown> | undefined): Task | null {
 
 function parseTasks(rows: Record<string, unknown>[]): Task[] {
   return rows.map((row) => parseTask(row)!)
+}
+
+function safeSyncProjectTasks(db: Database, projectId: string): void {
+  try {
+    syncProjectTasksFromFilesystem(db, projectId)
+  } catch (error) {
+    console.error(`[tasks] failed to sync project ${projectId} from filesystem`, error)
+  }
 }
 
 function cleanupTask(db: Database, taskId: string): void {
@@ -201,6 +214,7 @@ export function updateTask(db: Database, data: UpdateTaskInput): Task | null {
   const existing = db.prepare('SELECT project_id FROM tasks WHERE id = ?').get(data.id) as
     | { project_id: string }
     | undefined
+  const existingProjectId = existing?.project_id ?? null
   const projectChanged = data.projectId !== undefined && existing?.project_id !== data.projectId
 
   const fields: string[] = []
@@ -291,7 +305,14 @@ export function updateTask(db: Database, data: UpdateTaskInput): Task | null {
   }
 
   const row = db.prepare('SELECT * FROM tasks WHERE id = ?').get(data.id) as Record<string, unknown> | undefined
-  return parseTask(row)
+  const parsed = parseTask(row)
+  if (projectChanged) {
+    deleteTaskFromFilesystem(db, data.id, existingProjectId)
+  }
+  if (parsed) {
+    writeTaskToFilesystem(db, parsed)
+  }
+  return parsed
 }
 
 export function registerTaskHandlers(ipcMain: IpcMain, db: Database): void {
@@ -308,6 +329,7 @@ export function registerTaskHandlers(ipcMain: IpcMain, db: Database): void {
   })
 
   ipcMain.handle('db:tasks:getByProject', (_, projectId: string) => {
+    safeSyncProjectTasks(db, projectId)
     const rows = db
       .prepare(
         `SELECT t.*, el.external_url AS linear_url
@@ -338,16 +360,11 @@ export function registerTaskHandlers(ipcMain: IpcMain, db: Database): void {
       ?? 'claude-code'
 
     // Build provider_config from defaults + overrides
-    const providerConfig: ProviderConfig = {}
     const legacyOverrides: Record<string, string | undefined> = {
       'claude-code': data.claudeFlags, 'codex': data.codexFlags,
       'cursor-agent': data.cursorFlags, 'gemini': data.geminiFlags, 'opencode': data.opencodeFlags,
     }
-    for (const [mode, def] of Object.entries(PROVIDER_DEFAULTS)) {
-      const dbDefault = (db.prepare('SELECT value FROM settings WHERE key = ?')
-        .get(def.settingsKey) as { value: string } | undefined)?.value ?? def.fallback
-      providerConfig[mode] = { flags: legacyOverrides[mode] ?? dbDefault }
-    }
+    const providerConfig = buildDefaultProviderConfig(db, legacyOverrides)
 
     const stmt = db.prepare(`
       INSERT INTO tasks (
@@ -371,7 +388,11 @@ export function registerTaskHandlers(ipcMain: IpcMain, db: Database): void {
     )
     maybeAutoCreateWorktree(db, id, data.projectId, data.title)
     const row = db.prepare('SELECT * FROM tasks WHERE id = ?').get(id) as Record<string, unknown> | undefined
-    return parseTask(row)
+    const parsed = parseTask(row)
+    if (parsed) {
+      writeTaskToFilesystem(db, parsed)
+    }
+    return parsed
   })
 
   ipcMain.handle('db:tasks:getSubTasks', (_, parentId: string) => {
@@ -389,9 +410,29 @@ export function registerTaskHandlers(ipcMain: IpcMain, db: Database): void {
 
   ipcMain.handle('db:tasks:update', (_, data: UpdateTaskInput) => updateTask(db, data))
 
+  ipcMain.handle('db:tasks:syncFromProject', (_, projectId: string) => {
+    safeSyncProjectTasks(db, projectId)
+  })
+
   ipcMain.handle('db:tasks:delete', (_, id: string) => {
+    const affected = db.prepare(`
+      WITH RECURSIVE descendants(id, project_id) AS (
+        SELECT id, project_id FROM tasks WHERE id = ?
+        UNION ALL
+        SELECT t.id, t.project_id
+        FROM tasks t
+        JOIN descendants d ON t.parent_id = d.id
+      )
+      SELECT id, project_id FROM descendants
+    `).all(id) as Array<{ id: string; project_id: string }>
+
     cleanupTask(db, id)
     const result = db.prepare('DELETE FROM tasks WHERE id = ?').run(id)
+    if (result.changes > 0) {
+      for (const task of affected) {
+        deleteTaskFromFilesystem(db, task.id, task.project_id)
+      }
+    }
     return result.changes > 0
   })
 
@@ -406,7 +447,14 @@ export function registerTaskHandlers(ipcMain: IpcMain, db: Database): void {
       WHERE id = ? OR parent_id = ?
     `).run(id, id)
     const row = db.prepare('SELECT * FROM tasks WHERE id = ?').get(id) as Record<string, unknown> | undefined
-    return parseTask(row)
+    const archived = parseTask(row)
+    if (archived) writeTaskToFilesystem(db, archived)
+    for (const childId of childIds) {
+      const childRow = db.prepare('SELECT * FROM tasks WHERE id = ?').get(childId) as Record<string, unknown> | undefined
+      const child = parseTask(childRow)
+      if (child) writeTaskToFilesystem(db, child)
+    }
+    return archived
   })
 
   ipcMain.handle('db:tasks:archiveMany', (_, ids: string[]) => {
@@ -424,6 +472,10 @@ export function registerTaskHandlers(ipcMain: IpcMain, db: Database): void {
       UPDATE tasks SET archived_at = datetime('now'), worktree_path = NULL, updated_at = datetime('now')
       WHERE id IN (${placeholders})
     `).run(...allIds)
+    const rows = db.prepare(`SELECT * FROM tasks WHERE id IN (${placeholders})`).all(...allIds) as Record<string, unknown>[]
+    for (const task of parseTasks(rows)) {
+      writeTaskToFilesystem(db, task)
+    }
   })
 
   ipcMain.handle('db:tasks:unarchive', (_, id: string) => {
@@ -432,7 +484,9 @@ export function registerTaskHandlers(ipcMain: IpcMain, db: Database): void {
       WHERE id = ?
     `).run(id)
     const row = db.prepare('SELECT * FROM tasks WHERE id = ?').get(id) as Record<string, unknown> | undefined
-    return parseTask(row)
+    const task = parseTask(row)
+    if (task) writeTaskToFilesystem(db, task)
+    return task
   })
 
   ipcMain.handle('db:tasks:getArchived', () => {
@@ -450,6 +504,12 @@ export function registerTaskHandlers(ipcMain: IpcMain, db: Database): void {
         stmt.run(index, id)
       })
     })()
+    if (taskIds.length === 0) return
+    const placeholders = taskIds.map(() => '?').join(',')
+    const rows = db.prepare(`SELECT * FROM tasks WHERE id IN (${placeholders})`).all(...taskIds) as Record<string, unknown>[]
+    for (const task of parseTasks(rows)) {
+      writeTaskToFilesystem(db, task)
+    }
   })
 
   // Task Dependencies

--- a/packages/domains/task/src/main/task-files.ts
+++ b/packages/domains/task/src/main/task-files.ts
@@ -1,0 +1,405 @@
+import fs from 'fs'
+import path from 'path'
+import type { Database } from 'better-sqlite3'
+import type { ProviderConfig, Task } from '@slayzone/task/shared'
+import { PROVIDER_DEFAULTS } from '@slayzone/task/shared'
+
+interface ProjectStorageRow {
+  path: string | null
+  task_storage: string | null
+}
+
+interface RawFileTask {
+  id: string
+  title: string
+  description: string | null
+  status: string
+  priority: number
+  order: number
+  assignee: string | null
+  due_date: string | null
+  parent_id: string | null
+  archived_at: string | null
+  terminal_mode: string
+  terminal_shell: string | null
+  provider_config: ProviderConfig
+  dangerously_skip_permissions: boolean
+  panel_visibility: unknown
+  worktree_path: string | null
+  worktree_parent_branch: string | null
+  browser_url: string | null
+  browser_tabs: unknown
+  web_panel_urls: unknown
+  web_panel_resolutions: unknown
+  editor_open_files: unknown
+  merge_state: string | null
+  merge_context: unknown
+  is_temporary: boolean
+  created_at: string
+  updated_at: string
+}
+
+const TASKS_RELATIVE_DIR = path.join('docs', 'tasks')
+const REPOSITORY_TASK_STORAGE = 'repository'
+
+function safeJsonParse(value: unknown): unknown {
+  if (typeof value !== 'string') return value
+  try {
+    return JSON.parse(value)
+  } catch {
+    return value
+  }
+}
+
+function getProjectStorage(db: Database, projectId: string): ProjectStorageRow | null {
+  const row = db
+    .prepare('SELECT path, task_storage FROM projects WHERE id = ?')
+    .get(projectId) as ProjectStorageRow | undefined
+  return row ?? null
+}
+
+function isRepositoryTaskStorage(project: ProjectStorageRow | null): boolean {
+  return project?.task_storage === REPOSITORY_TASK_STORAGE
+}
+
+function getTasksDirectory(projectPath: string): string {
+  return path.join(projectPath, TASKS_RELATIVE_DIR)
+}
+
+function toNullableString(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null
+}
+
+function toNumber(value: unknown, fallback: number): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string') {
+    const parsed = Number(value)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return fallback
+}
+
+function toBoolean(value: unknown, fallback: boolean): boolean {
+  if (typeof value === 'boolean') return value
+  if (typeof value === 'number') return value !== 0
+  if (typeof value === 'string') {
+    const lower = value.toLowerCase()
+    if (lower === '1' || lower === 'true') return true
+    if (lower === '0' || lower === 'false') return false
+  }
+  return fallback
+}
+
+function getTaskJsonPath(projectPath: string, taskId: string): string {
+  return path.join(getTasksDirectory(projectPath), `${taskId}.json`)
+}
+
+export function buildDefaultProviderConfig(
+  db: Database,
+  overrides?: Record<string, string | undefined>
+): ProviderConfig {
+  const providerConfig: ProviderConfig = {}
+  for (const [mode, def] of Object.entries(PROVIDER_DEFAULTS)) {
+    const setting = (db.prepare('SELECT value FROM settings WHERE key = ?')
+      .get(def.settingsKey) as { value: string } | undefined)?.value
+    providerConfig[mode] = { flags: overrides?.[mode] ?? setting ?? def.fallback }
+  }
+  return providerConfig
+}
+
+function buildProviderConfigFromMetadata(
+  metadata: Record<string, unknown>,
+  defaultProviderConfig: ProviderConfig
+): ProviderConfig {
+  const merged: ProviderConfig = {}
+  for (const [mode, entry] of Object.entries(defaultProviderConfig)) {
+    merged[mode] = { ...entry }
+  }
+
+  const rawConfig = safeJsonParse(metadata.provider_config)
+  if (rawConfig && typeof rawConfig === 'object' && !Array.isArray(rawConfig)) {
+    for (const [mode, entry] of Object.entries(rawConfig as Record<string, unknown>)) {
+      if (entry && typeof entry === 'object' && !Array.isArray(entry)) {
+        const normalized = entry as { conversationId?: unknown; flags?: unknown }
+        merged[mode] = {
+          ...merged[mode],
+          ...(normalized.conversationId !== undefined
+            ? { conversationId: normalized.conversationId as string | null }
+            : {}),
+          ...(normalized.flags !== undefined
+            ? { flags: typeof normalized.flags === 'string' ? normalized.flags : '' }
+            : {})
+        }
+      }
+    }
+  }
+
+  const legacyFlagMappings: Array<{ mode: string; key: string }> = [
+    { mode: 'claude-code', key: 'claude_flags' },
+    { mode: 'codex', key: 'codex_flags' },
+    { mode: 'cursor-agent', key: 'cursor_flags' },
+    { mode: 'gemini', key: 'gemini_flags' },
+    { mode: 'opencode', key: 'opencode_flags' }
+  ]
+  for (const mapping of legacyFlagMappings) {
+    const override = toNullableString(metadata[mapping.key])
+    if (override !== null) {
+      merged[mapping.mode] = { ...merged[mapping.mode], flags: override }
+    }
+  }
+
+  return merged
+}
+
+function readTaskFilesFromDirectory(
+  tasksDir: string,
+  defaultTerminalMode: string,
+  defaultProviderConfig: ProviderConfig
+): RawFileTask[] {
+  if (!fs.existsSync(tasksDir)) return []
+
+  const files = fs
+    .readdirSync(tasksDir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && path.extname(entry.name).toLowerCase() === '.json')
+    .map((entry) => entry.name)
+    .sort((a, b) => a.localeCompare(b))
+
+  const rawTasks: RawFileTask[] = []
+  const seenTaskIds = new Set<string>()
+  const now = new Date().toISOString()
+
+  for (const fileName of files) {
+    const filePath = path.join(tasksDir, fileName)
+    const fileBase = path.basename(fileName, '.json')
+
+    let metadata: Record<string, unknown> = {}
+    try {
+      const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8')) as unknown
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        metadata = parsed as Record<string, unknown>
+      }
+    } catch (error) {
+      console.error(`Failed parsing task file ${filePath}`, error)
+      continue
+    }
+
+    const id = toNullableString(metadata.id) ?? fileBase
+    if (seenTaskIds.has(id)) continue
+    seenTaskIds.add(id)
+
+    const providerConfig = buildProviderConfigFromMetadata(metadata, defaultProviderConfig)
+    rawTasks.push({
+      id,
+      title: toNullableString(metadata.title) ?? fileBase,
+      description: toNullableString(metadata.description),
+      status: toNullableString(metadata.status) ?? 'inbox',
+      priority: toNumber(metadata.priority, 3),
+      order: toNumber(metadata.order, rawTasks.length),
+      assignee: toNullableString(metadata.assignee),
+      due_date: toNullableString(metadata.due_date),
+      parent_id: toNullableString(metadata.parent_id),
+      archived_at: toNullableString(metadata.archived_at),
+      terminal_mode: toNullableString(metadata.terminal_mode) ?? defaultTerminalMode,
+      terminal_shell: toNullableString(metadata.terminal_shell),
+      provider_config: providerConfig,
+      dangerously_skip_permissions: toBoolean(metadata.dangerously_skip_permissions, false),
+      panel_visibility: safeJsonParse(metadata.panel_visibility),
+      worktree_path: toNullableString(metadata.worktree_path),
+      worktree_parent_branch: toNullableString(metadata.worktree_parent_branch),
+      browser_url: toNullableString(metadata.browser_url),
+      browser_tabs: safeJsonParse(metadata.browser_tabs),
+      web_panel_urls: safeJsonParse(metadata.web_panel_urls),
+      web_panel_resolutions: safeJsonParse(metadata.web_panel_resolutions),
+      editor_open_files: safeJsonParse(metadata.editor_open_files),
+      merge_state: toNullableString(metadata.merge_state),
+      merge_context: safeJsonParse(metadata.merge_context),
+      is_temporary: toBoolean(metadata.is_temporary, false),
+      created_at: toNullableString(metadata.created_at) ?? now,
+      updated_at: toNullableString(metadata.updated_at) ?? now
+    })
+  }
+
+  return rawTasks
+}
+
+export function syncProjectTasksFromFilesystem(db: Database, projectId: string): void {
+  const project = getProjectStorage(db, projectId)
+  if (!project?.path || !isRepositoryTaskStorage(project)) return
+
+  const tasksDir = getTasksDirectory(project.path)
+  if (!fs.existsSync(tasksDir)) return
+
+  const defaultTerminalMode =
+    ((db.prepare("SELECT value FROM settings WHERE key = 'default_terminal_mode'").get() as
+      | { value: string }
+      | undefined)?.value) ?? 'claude-code'
+  const defaultProviderConfig = buildDefaultProviderConfig(db)
+  const tasks = readTaskFilesFromDirectory(tasksDir, defaultTerminalMode, defaultProviderConfig)
+  if (tasks.length === 0) return
+
+  const upsert = db.prepare(`
+    INSERT INTO tasks (
+      id, project_id, parent_id, title, description, assignee, status, priority, "order",
+      due_date, archived_at, terminal_mode, terminal_shell, provider_config,
+      claude_conversation_id, codex_conversation_id, cursor_conversation_id, gemini_conversation_id, opencode_conversation_id,
+      claude_flags, codex_flags, cursor_flags, gemini_flags, opencode_flags,
+      dangerously_skip_permissions, panel_visibility, worktree_path, worktree_parent_branch,
+      browser_url, browser_tabs, web_panel_urls, web_panel_resolutions, editor_open_files,
+      merge_state, merge_context, is_temporary, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(id) DO UPDATE SET
+      project_id = excluded.project_id,
+      parent_id = excluded.parent_id,
+      title = excluded.title,
+      description = excluded.description,
+      assignee = excluded.assignee,
+      status = excluded.status,
+      priority = excluded.priority,
+      "order" = excluded."order",
+      due_date = excluded.due_date,
+      archived_at = excluded.archived_at,
+      terminal_mode = excluded.terminal_mode,
+      terminal_shell = excluded.terminal_shell,
+      provider_config = excluded.provider_config,
+      claude_conversation_id = excluded.claude_conversation_id,
+      codex_conversation_id = excluded.codex_conversation_id,
+      cursor_conversation_id = excluded.cursor_conversation_id,
+      gemini_conversation_id = excluded.gemini_conversation_id,
+      opencode_conversation_id = excluded.opencode_conversation_id,
+      claude_flags = excluded.claude_flags,
+      codex_flags = excluded.codex_flags,
+      cursor_flags = excluded.cursor_flags,
+      gemini_flags = excluded.gemini_flags,
+      opencode_flags = excluded.opencode_flags,
+      dangerously_skip_permissions = excluded.dangerously_skip_permissions,
+      panel_visibility = excluded.panel_visibility,
+      worktree_path = excluded.worktree_path,
+      worktree_parent_branch = excluded.worktree_parent_branch,
+      browser_url = excluded.browser_url,
+      browser_tabs = excluded.browser_tabs,
+      web_panel_urls = excluded.web_panel_urls,
+      web_panel_resolutions = excluded.web_panel_resolutions,
+      editor_open_files = excluded.editor_open_files,
+      merge_state = excluded.merge_state,
+      merge_context = excluded.merge_context,
+      is_temporary = excluded.is_temporary,
+      updated_at = excluded.updated_at
+  `)
+
+  db.transaction(() => {
+    for (const task of tasks) {
+      upsert.run(
+        task.id,
+        projectId,
+        null,
+        task.title,
+        task.description,
+        task.assignee,
+        task.status,
+        task.priority,
+        task.order,
+        task.due_date,
+        task.archived_at,
+        task.terminal_mode,
+        task.terminal_shell,
+        JSON.stringify(task.provider_config),
+        task.provider_config['claude-code']?.conversationId ?? null,
+        task.provider_config['codex']?.conversationId ?? null,
+        task.provider_config['cursor-agent']?.conversationId ?? null,
+        task.provider_config['gemini']?.conversationId ?? null,
+        task.provider_config['opencode']?.conversationId ?? null,
+        task.provider_config['claude-code']?.flags ?? '',
+        task.provider_config['codex']?.flags ?? '',
+        task.provider_config['cursor-agent']?.flags ?? '',
+        task.provider_config['gemini']?.flags ?? '',
+        task.provider_config['opencode']?.flags ?? '',
+        task.dangerously_skip_permissions ? 1 : 0,
+        task.panel_visibility ? JSON.stringify(task.panel_visibility) : null,
+        task.worktree_path,
+        task.worktree_parent_branch,
+        task.browser_url,
+        task.browser_tabs ? JSON.stringify(task.browser_tabs) : null,
+        task.web_panel_urls ? JSON.stringify(task.web_panel_urls) : null,
+        task.web_panel_resolutions ? JSON.stringify(task.web_panel_resolutions) : null,
+        task.editor_open_files ? JSON.stringify(task.editor_open_files) : null,
+        task.merge_state,
+        task.merge_context ? JSON.stringify(task.merge_context) : null,
+        task.is_temporary ? 1 : 0,
+        task.created_at,
+        task.updated_at
+      )
+    }
+
+    const linkParent = db.prepare(`
+      UPDATE tasks
+      SET parent_id = ?
+      WHERE id = ?
+        AND EXISTS (SELECT 1 FROM tasks parent WHERE parent.id = ?)
+    `)
+
+    for (const task of tasks) {
+      if (!task.parent_id) continue
+      linkParent.run(task.parent_id, task.id, task.parent_id)
+    }
+  })()
+}
+
+export function writeTaskToFilesystem(db: Database, task: Task): void {
+  const project = getProjectStorage(db, task.project_id)
+  if (!project?.path || !isRepositoryTaskStorage(project)) return
+
+  const tasksDir = getTasksDirectory(project.path)
+  fs.mkdirSync(tasksDir, { recursive: true })
+
+  const payload: Record<string, unknown> = {
+    id: task.id,
+    title: task.title,
+    description: task.description,
+    status: task.status,
+    priority: task.priority,
+    order: task.order,
+    assignee: task.assignee,
+    due_date: task.due_date,
+    parent_id: task.parent_id,
+    archived_at: task.archived_at,
+    terminal_mode: task.terminal_mode,
+    terminal_shell: task.terminal_shell,
+    provider_config: task.provider_config,
+    dangerously_skip_permissions: task.dangerously_skip_permissions,
+    panel_visibility: task.panel_visibility,
+    worktree_path: task.worktree_path,
+    worktree_parent_branch: task.worktree_parent_branch,
+    browser_url: task.browser_url,
+    browser_tabs: task.browser_tabs,
+    web_panel_urls: task.web_panel_urls,
+    web_panel_resolutions: task.web_panel_resolutions,
+    editor_open_files: task.editor_open_files,
+    merge_state: task.merge_state,
+    merge_context: task.merge_context,
+    is_temporary: task.is_temporary,
+    created_at: task.created_at,
+    updated_at: task.updated_at
+  }
+
+  fs.writeFileSync(getTaskJsonPath(project.path, task.id), `${JSON.stringify(payload, null, 2)}\n`, 'utf8')
+}
+
+export function deleteTaskFromFilesystem(
+  db: Database,
+  taskId: string,
+  projectId: string | null | undefined
+): void {
+  if (!projectId) return
+  const project = getProjectStorage(db, projectId)
+  if (!project?.path || !isRepositoryTaskStorage(project)) return
+
+  const filePath = getTaskJsonPath(project.path, taskId)
+  try {
+    fs.unlinkSync(filePath)
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException
+    if (err.code !== 'ENOENT') {
+      console.error(`Failed deleting task file ${filePath}`, error)
+    }
+  }
+}

--- a/packages/domains/task/src/shared/schemas.ts
+++ b/packages/domains/task/src/shared/schemas.ts
@@ -32,7 +32,8 @@ export const updateTaskSchema = z.object({
 // Project creation schema
 export const createProjectSchema = z.object({
   name: z.string().min(1, 'Name required').max(100, 'Name too long'),
-  color: z.string().regex(/^#[0-9a-fA-F]{6}$/, 'Invalid hex color')
+  color: z.string().regex(/^#[0-9a-fA-F]{6}$/, 'Invalid hex color'),
+  taskStorage: z.enum(['database', 'repository']).optional()
 })
 
 // Project update schema
@@ -42,7 +43,8 @@ export const updateProjectSchema = z.object({
   color: z
     .string()
     .regex(/^#[0-9a-fA-F]{6}$/)
-    .optional()
+    .optional(),
+  taskStorage: z.enum(['database', 'repository']).optional()
 })
 
 // Form data types - explicit for forms

--- a/packages/shared/types/src/api.ts
+++ b/packages/shared/types/src/api.ts
@@ -139,6 +139,7 @@ export interface ElectronAPI {
     getTasksByProject: (projectId: string) => Promise<Task[]>
     getTask: (id: string) => Promise<Task | null>
     getSubTasks: (parentId: string) => Promise<Task[]>
+    syncTasksFromProject: (projectId: string) => Promise<void>
     createTask: (data: CreateTaskInput) => Promise<Task>
     updateTask: (data: UpdateTaskInput) => Promise<Task>
     deleteTask: (id: string) => Promise<boolean>


### PR DESCRIPTION
## Summary
Adds per-project task storage mode and repository-backed task persistence in JSON.

## Why
Projects that live in local repos need portable, source-controlled task data instead of SQLite-only storage.

## What changed
- Added `projects.task_storage` (`database | repository`) with migration defaulting to `database`.
- Added project setup selector in Create Project dialog:
  - `Database (SQLite)`
  - `Repository (docs/tasks/*.json)`
- Added/extended project types and IPC payloads to support `taskStorage`.
- Implemented repository task adapter:
  - Reads tasks from `docs/tasks/*.json`
  - Writes updates to `docs/tasks/<taskId>.json`
  - Deletes JSON files when tasks are deleted
- Wired sync behavior:
  - On project creation in repository mode, import existing `docs/tasks/*.json`.
  - On task CRUD/archive/reorder, persist JSON when project mode is `repository`.
- Updated tests and schema typings to cover the new mode and JSON flow.

## Data / migration impact
- Migration adds `task_storage` to `projects` with default `database`.
- Existing projects keep current behavior unless changed to `repository`.

## Behavior
- `database` mode: tasks persist in SQLite only.
- `repository` mode: tasks persist in `docs/tasks/*.json` and are re-importable when project is recreated with same repo path + repository mode.

## Validation
- `pnpm --filter @slayzone/app run typecheck`
- Repo gate passes (`$HOME/.codex/scripts/gate`)
- Contract tests updated for:
  - project storage mode create/update
  - repository JSON write/import paths
  - database mode no file writes

## Risks / notes
- Repository mode requires project `path` to be set.
- JSON is intentionally canonical format for repo-backed tasks (no yaml/md fallback).
