### PR TITLE
fix(leaderboard): prevent crash when Convex is not configured

### DIFF
--- a/packages/apps/app/src/renderer/src/App.tsx
+++ b/packages/apps/app/src/renderer/src/App.tsx
@@ -56,6 +56,23 @@ import { UsagePopover } from '@/components/usage/UsagePopover'
 import { useUsage } from '@/components/usage/useUsage'
 import { useQuery } from 'convex/react'
 import { api } from 'convex/_generated/api'
+
+// Fetches leaderboard rank only when ConvexProvider is in the tree (i.e. VITE_CONVEX_URL is set).
+// Calling useQuery unconditionally in App crashes when no ConvexProvider exists.
+function LeaderboardRankQuery({
+  isAuthenticated,
+  onRank
+}: {
+  isAuthenticated: boolean
+  onRank: (rank: number | null) => void
+}): null {
+  const rank = useQuery(
+    api.leaderboard.getMyBestRank,
+    import.meta.env.DEV && isAuthenticated ? {} : 'skip'
+  ) ?? null
+  React.useEffect(() => { onRank(rank) }, [rank, onRank])
+  return null
+}
 import { useLeaderboardAuth } from '@/lib/convexAuth'
 
 type HomePanel = 'kanban' | 'git' | 'editor' | 'processes'
@@ -160,10 +177,7 @@ function App(): React.JSX.Element {
 
   // Leaderboard rank for tab badge
   const leaderboardAuth = useLeaderboardAuth()
-  const leaderboardBestRank = useQuery(
-    api.leaderboard.getMyBestRank,
-    import.meta.env.DEV && leaderboardAuth.configured && leaderboardAuth.isAuthenticated ? {} : 'skip'
-  ) ?? null
+  const [leaderboardBestRank, setLeaderboardBestRank] = useState<number | null>(null)
 
   // Usage & notification state
   const { data: usageData, refresh: refreshUsage } = useUsage()
@@ -884,6 +898,12 @@ function App(): React.JSX.Element {
 
   return (
     <SidebarProvider defaultOpen={true}>
+      {leaderboardAuth.configured && (
+        <LeaderboardRankQuery
+          isAuthenticated={leaderboardAuth.isAuthenticated}
+          onRank={setLeaderboardBestRank}
+        />
+      )}
       <div id="app-shell" className="h-full w-full flex">
         <AppSidebar
           projects={projects}

--- a/packages/apps/app/src/renderer/src/components/leaderboard/LeaderboardPage.tsx
+++ b/packages/apps/app/src/renderer/src/components/leaderboard/LeaderboardPage.tsx
@@ -72,6 +72,18 @@ function hasResolvedGithubIdentity(viewer: ViewerProfile | null): boolean {
 }
 
 export function LeaderboardPage(): React.JSX.Element {
+  const auth = useLeaderboardAuth()
+  if (!auth.configured) {
+    return (
+      <div className="h-full overflow-hidden flex items-center justify-center text-sm text-muted-foreground">
+        Leaderboard unavailable (Convex not configured)
+      </div>
+    )
+  }
+  return <LeaderboardPageInner />
+}
+
+function LeaderboardPageInner(): React.JSX.Element {
   const [period, setPeriod] = useState<Period>('all-time')
   const [authBusy, setAuthBusy] = useState(false)
   const [syncing, setSyncing] = useState(false)


### PR DESCRIPTION
Fixes a crash in the React renderer caused by calling Convex `useQuery` and `useMutation` hooks unconditionally when the `ConvexProvider` is not in the tree (which happens when `VITE_CONVEX_URL` is not set, strictly on first launch or in manual dev mode).

The fixes:
1. **App.tsx**: Moved the `useQuery(api.leaderboard.getMyBestRank)` call into a `LeaderboardRankQuery` guard component that only renders when Convex is configured.
2. **LeaderboardPage.tsx**: Same issue; it uses 4 Convex hooks unconditionally. Split it into `LeaderboardPage` (guard wrapper) and `LeaderboardPageInner` (using the hooks).

This prevents the app from silently crashing to a black screen without Convex.
