### PR TITLE
fix(worktrees): handle unicode filenames and null paths in git diff

### DIFF
--- a/packages/domains/worktrees/src/main/git-worktree.ts
+++ b/packages/domains/worktrees/src/main/git-worktree.ts
@@ -529,6 +529,7 @@ export function unstageAll(path: string): void {
 }
 
 export function getUntrackedFileDiff(repoPath: string, filePath: string): string {
+  if (!filePath) return ''
   try {
     const devNull = platform() === 'win32' ? 'NUL' : '/dev/null'
     return spawnGit(['diff', '--no-index', '--no-ext-diff', '--', devNull, filePath], { cwd: repoPath })
@@ -558,15 +559,15 @@ export function getWorkingDiff(path: string, opts?: { contextLines?: string; ign
   }
   const extra = extraFlags.length > 0 ? ' ' + extraFlags.join(' ') : ''
 
-  const unstagedFilesRaw = execGit('git diff --name-only', {
+  const unstagedFilesRaw = execGit('git diff --name-only -z', {
     cwd: path,
     encoding: 'utf-8'
   }) as string
-  const stagedFilesRaw = execGit('git diff --cached --name-only', {
+  const stagedFilesRaw = execGit('git diff --cached --name-only -z', {
     cwd: path,
     encoding: 'utf-8'
   }) as string
-  const untrackedFilesRaw = execGit('git ls-files --others --exclude-standard', {
+  const untrackedFilesRaw = execGit('git ls-files --others --exclude-standard -z', {
     cwd: path,
     encoding: 'utf-8'
   }) as string
@@ -579,9 +580,9 @@ export function getWorkingDiff(path: string, opts?: { contextLines?: string; ign
     encoding: 'utf-8'
   }) as string
 
-  const unstagedFiles = unstagedFilesRaw.trim().split('\n').filter(Boolean)
-  const stagedFiles = stagedFilesRaw.trim().split('\n').filter(Boolean)
-  const untrackedFiles = untrackedFilesRaw.trim().split('\n').filter(Boolean)
+  const unstagedFiles = unstagedFilesRaw.split('\0').filter(Boolean)
+  const stagedFiles = stagedFilesRaw.split('\0').filter(Boolean)
+  const untrackedFiles = untrackedFilesRaw.split('\0').filter(Boolean)
 
   return {
     targetPath: path,

--- a/packages/domains/worktrees/src/main/handlers.test.ts
+++ b/packages/domains/worktrees/src/main/handlers.test.ts
@@ -241,6 +241,33 @@ describe('git:getUntrackedFileDiff', () => {
     expect(diff.includes('hello')).toBe(true)
     fs.unlinkSync(path.join(repoPath, 'new-untracked.txt'))
   })
+
+  test('returns empty string for null filePath', () => {
+    const diff = h.invoke('git:getUntrackedFileDiff', repoPath, null as unknown as string) as string
+    expect(diff).toBe('')
+  })
+
+  test('returns diff for file with unicode name', () => {
+    const unicodeName = 'Protokoll från möte.txt'
+    fs.writeFileSync(path.join(repoPath, unicodeName), 'unicode content')
+    const diff = h.invoke('git:getUntrackedFileDiff', repoPath, unicodeName) as string
+    expect(diff.includes('unicode content')).toBe(true)
+    fs.unlinkSync(path.join(repoPath, unicodeName))
+  })
+})
+
+describe('git:getWorkingDiff unicode', () => {
+  test('lists untracked files with unicode names', () => {
+    const unicodeName = 'ändring av avtal.txt'
+    fs.writeFileSync(path.join(repoPath, unicodeName), 'swedish chars')
+    const diff = h.invoke('git:getWorkingDiff', repoPath) as {
+      untrackedFiles: string[]
+      files: string[]
+    }
+    expect(diff.untrackedFiles).toContain(unicodeName)
+    expect(diff.files).toContain(unicodeName)
+    fs.unlinkSync(path.join(repoPath, unicodeName))
+  })
 })
 
 // --- Commit ---


### PR DESCRIPTION
## Summary

Console was flooded with `Could not access` errors from `getUntrackedFileDiff` for two reasons:

1. **Unicode filenames** — `git ls-files` and `git diff --name-only` without `-z` quote non-ASCII paths with octal escapes (e.g. `\303\245`). The quoted form was then passed to `git diff --no-index` which couldn't find the file.

2. **Null paths** — Null values reaching `getUntrackedFileDiff` via IPC got stringified to the literal string `"null"`, producing errors like `Could not access 'Orpheus-TTS/null'`.

## Changes

- Add `-z` flag to `git ls-files --others --exclude-standard`, `git diff --name-only`, and `git diff --cached --name-only` for NUL-delimited output. Split on `\0` instead of `\n`.
- Add early return for falsy `filePath` in `getUntrackedFileDiff`.
- Tests for both cases (TDD — verified failing before fix).

---

*Built with Claude Code w/ Opus 4.6*

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes two root causes of `Could not access` console errors in `getUntrackedFileDiff`: git's default behaviour of octal-escaping non-ASCII paths in `--name-only` output, and `null` values being serialised to the literal string `"null"` over IPC before reaching the function.

- **Unicode filenames**: Adds the `-z` flag to `git diff --name-only`, `git diff --cached --name-only`, and `git ls-files --others --exclude-standard`, switching their output to NUL-delimited raw UTF-8 bytes. The downstream `.split('\n')` calls are updated to `.split('\0')`, correctly recovering the original filenames without octal encoding.
- **Null path guard**: Adds `if (!filePath) return ''` as the first statement in `getUntrackedFileDiff`, preventing falsy values from ever reaching `spawnGit`.
- **Tests**: Two new `describe` blocks cover both fixes — the null-path guard and unicode file listing via `getWorkingDiff` / `getUntrackedFileDiff`.
- The core logic change is minimal and isolated to `getWorkingDiff`; `getUntrackedFileDiff` already uses `spawnGit` with an argument array, so it was already safe from shell-injection and quoting issues once the upstream list was clean.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge; the changes are targeted, well-tested, and address a real bug with no regressions.
- The fix is minimal and correct: adding `-z` to git commands is idiomatic and well-understood, splitting on `\0` with `filter(Boolean)` handles both empty output and trailing NUL delimiters, and the falsy guard in `getUntrackedFileDiff` is a simple defensive check. Tests verify both scenarios. The only issue found is minor test hygiene (missing `try/finally` cleanup).
- No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/domains/worktrees/src/main/git-worktree.ts | Adds `-z` (NUL-delimited) flag to the three `git diff --name-only` / `git ls-files` calls and updates splitting logic; adds an early-return guard for falsy `filePath` in `getUntrackedFileDiff`. Changes are correct and complete. |
| packages/domains/worktrees/src/main/handlers.test.ts | Adds tests for the null-path guard and unicode filename handling. Logic is correct but both new file-creating tests lack `try/finally` cleanup, risking file leakage on assertion failure. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getWorkingDiff called] --> B[git diff --name-only -z]
    A --> C[git diff --cached --name-only -z]
    A --> D[git ls-files --others --exclude-standard -z]
    B --> E[split on NUL, filter empty]
    C --> E
    D --> E
    E --> F[unstagedFiles / stagedFiles / untrackedFiles arrays\ncontain raw UTF-8 filenames]
    F --> G[Return GitDiffSnapshot]
    G --> H[Caller iterates untrackedFiles]
    H --> I{filePath falsy?}
    I -- yes --> J[getUntrackedFileDiff returns '']
    I -- no --> K[spawnGit diff --no-index -- /dev/null filePath\nsafe: array args, no shell quoting]
    K --> L[Return diff string]
```
</details>

<sub>Last reviewed commit: 108446c</sub>

> Greptile also left **1 inline comment** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->