### PR TITLE
fix: use scoped electron-rebuild in postinstall

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,7 +1,7 @@
 const { execSync } = require('child_process')
 
 if (!process.env.CI_SKIP_POSTINSTALL) {
-  execSync('electron-rebuild -f -w better-sqlite3,node-pty', {
+  execSync('pnpm --filter @slayzone/app exec electron-rebuild -f -w better-sqlite3,node-pty', {
     stdio: 'inherit',
   })
 }


### PR DESCRIPTION
## Summary

`pnpm install` fails because the postinstall script calls `electron-rebuild` as a global command, but it's only installed as a dependency of `@slayzone/app`. Scopes the call through `pnpm --filter @slayzone/app exec` so it resolves from the correct package.

---

*Built with Claude Code w/ Opus 4.6*

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a broken `pnpm install` caused by the root `postinstall` script invoking `electron-rebuild` as if it were a globally available binary, when it is actually only installed as `@electron/rebuild` under `@slayzone/app`'s devDependencies. The fix scopes the invocation through `pnpm --filter @slayzone/app exec` so pnpm resolves the binary from `packages/apps/app/node_modules/.bin`, and also correctly sets the working directory to `packages/apps/app/` — the location where Electron is declared as a devDependency, which is what `electron-rebuild` needs to determine the target Electron ABI version.

- Changed `electron-rebuild -f -w better-sqlite3,node-pty` → `pnpm --filter @slayzone/app exec electron-rebuild -f -w better-sqlite3,node-pty` in `scripts/postinstall.js`.
- The approach is consistent with the rest of the root `package.json` scripts, which already use `pnpm --filter @slayzone/app exec` for other scoped commands (e.g. `release:patch`, `release:minor`).
- The `CI_SKIP_POSTINSTALL` guard and the set of rebuilt native modules (`better-sqlite3`, `node-pty`) are unchanged.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge — it is a minimal, targeted fix with no risk of regression.
- The change is a single-line fix that correctly addresses the root cause. The pattern (`pnpm --filter <pkg> exec`) is already used elsewhere in the root `package.json` scripts, the binary is confirmed to be a devDependency of `@slayzone/app`, and there are no side effects introduced. No logic changes, no new dependencies, no error handling removed.
- No files require special attention.
</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Dev as Developer / CI
    participant pnpm as pnpm install
    participant root as Root postinstall<br/>(scripts/postinstall.js)
    participant pnpmFilter as pnpm --filter @slayzone/app exec
    participant rebuild as electron-rebuild<br/>(@slayzone/app devDep)

    Dev->>pnpm: pnpm install
    pnpm->>root: run postinstall script
    root->>root: check CI_SKIP_POSTINSTALL
    alt CI_SKIP_POSTINSTALL not set
        root->>pnpmFilter: execSync(pnpm --filter @slayzone/app exec electron-rebuild -f -w better-sqlite3,node-pty)
        pnpmFilter->>rebuild: resolve binary from packages/apps/app/node_modules/.bin
        rebuild->>rebuild: rebuild better-sqlite3 & node-pty<br/>against Electron version in @slayzone/app
        rebuild-->>root: exit 0
    else CI_SKIP_POSTINSTALL set
        root->>root: skip (no-op)
    end
    root-->>pnpm: postinstall complete
    pnpm-->>Dev: install complete
```
</details>

<sub>Last reviewed commit: 81eefa1</sub>

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->