### PR TITLE
feat(task): custom working directory (base_dir)

### DIFF
--- a/packages/apps/app/src/main/db/migrations.ts
+++ b/packages/apps/app/src/main/db/migrations.ts
@@ -997,6 +997,12 @@ const migrations: Migration[] = [
         WHERE ccs_profile IS NOT NULL AND ccs_profile != ''
       `)
     }
+  },
+  {
+    version: 55,
+    up: (db) => {
+      db.exec(`ALTER TABLE tasks ADD COLUMN base_dir TEXT DEFAULT NULL`)
+    }
   }
 ]
 

--- a/packages/apps/app/src/renderer/src/components/notifications/useAttentionTasks.test.ts
+++ b/packages/apps/app/src/renderer/src/components/notifications/useAttentionTasks.test.ts
@@ -67,6 +67,7 @@ function makeTask(id: string, projectId: string, title: string): Task {
     panel_visibility: null,
     worktree_path: null,
     worktree_parent_branch: null,
+    base_dir: null,
     browser_url: null,
     browser_tabs: null,
     web_panel_urls: null,

--- a/packages/domains/task-terminals/src/client/TerminalContainer.tsx
+++ b/packages/domains/task-terminals/src/client/TerminalContainer.tsx
@@ -33,6 +33,7 @@ interface TerminalContainerProps {
   onRetry?: () => void
   onFocusRequestHandled?: (requestId: number) => void
   onMainTabActiveChange?: (isMainActive: boolean) => void
+  onMainReset?: () => void
   rightContent?: React.ReactNode
 }
 
@@ -55,6 +56,7 @@ export const TerminalContainer = forwardRef<TerminalContainerHandle, TerminalCon
   onRetry,
   onFocusRequestHandled,
   onMainTabActiveChange,
+  onMainReset,
   rightContent
 }: TerminalContainerProps, ref) {
   const {
@@ -293,6 +295,7 @@ export const TerminalContainer = forwardRef<TerminalContainerHandle, TerminalCon
         onPaneClose={closeTab}
         onPaneMove={movePane}
         onGroupRename={renameTab}
+        onMainReset={onMainReset}
         rightContent={rightContent}
       />
       <div className="flex-1 min-h-0">

--- a/packages/domains/task-terminals/src/client/TerminalTabBar.tsx
+++ b/packages/domains/task-terminals/src/client/TerminalTabBar.tsx
@@ -14,6 +14,7 @@ interface TerminalTabBarProps {
   onPaneClose: (tabId: string) => void
   onPaneMove: (tabId: string, targetGroupId: string | null) => void
   onGroupRename: (tabId: string, label: string | null) => void
+  onMainReset?: () => void
   rightContent?: React.ReactNode
 }
 
@@ -55,6 +56,7 @@ export function TerminalTabBar({
   onPaneClose,
   onPaneMove,
   onGroupRename,
+  onMainReset,
   rightContent
 }: TerminalTabBarProps) {
   const [editingTabId, setEditingTabId] = useState<string | null>(null)
@@ -211,6 +213,19 @@ export function TerminalTabBar({
                       )}
                       {tab.isMain && (
                         <span className="text-[10px] text-orange-300/80 bg-orange-400/10 px-1.5 rounded-full">main</span>
+                      )}
+                      {tab.isMain && onMainReset && (
+                        <button
+                          data-testid="terminal-main-reset"
+                          className="h-4 w-4 rounded hover:bg-neutral-300/50 dark:hover:bg-neutral-600/50 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
+                          onClick={e => {
+                            e.stopPropagation()
+                            onMainReset()
+                          }}
+                          title="Reset terminal session"
+                        >
+                          <X className="size-3" />
+                        </button>
                       )}
                       {!tab.isMain && (
                         <button

--- a/packages/domains/task/src/client/TaskDetailPage.tsx
+++ b/packages/domains/task/src/client/TaskDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
-import { MoreHorizontal, Archive, Trash2, AlertTriangle, Sparkles, Loader2, Terminal as TerminalIcon, Globe, Settings2, GitBranch, FileCode, ChevronRight, Plus, GripVertical, Camera, X, Info, CheckCircle2, XCircle, Stethoscope, Cpu } from 'lucide-react'
+import { MoreHorizontal, Archive, Trash2, AlertTriangle, Sparkles, Loader2, Terminal as TerminalIcon, Globe, Settings2, GitBranch, FileCode, ChevronRight, Plus, GripVertical, Camera, X, Info, CheckCircle2, XCircle, Stethoscope, Cpu, FolderOpen } from 'lucide-react'
 import { DndContext, PointerSensor, useSensors, useSensor, closestCenter, type DragEndEvent } from '@dnd-kit/core'
 import { SortableContext, useSortable, verticalListSortingStrategy, arrayMove } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
@@ -969,7 +969,7 @@ export function TaskDetailPage({
 
       if (e.metaKey && !e.shiftKey) {
         // Cmd+P: quick open — works even inside CodeMirror
-        const editorProjectPath = task?.worktree_path || project?.path
+        const editorProjectPath = task?.worktree_path || task?.base_dir || project?.path
         if (e.key === 'p' && isBuiltinEnabled('editor') && editorProjectPath) {
           e.preventDefault()
           setQuickOpenVisible(true)
@@ -1145,24 +1145,54 @@ export function TaskDetailPage({
   }
 
   // Wrapper for GitPanel that calls API and notifies parent
-  const updateTaskAndNotify = async (data: { id: string; worktreePath?: string | null; worktreeParentBranch?: string | null; browserUrl?: string | null; status?: Task['status'] }): Promise<Task> => {
-    // If worktreePath is changing, kill old PTY first so terminal restarts with new cwd
-    if (data.worktreePath !== undefined) {
+  const updateTaskAndNotify = async (data: { id: string; worktreePath?: string | null; worktreeParentBranch?: string | null; baseDir?: string | null; browserUrl?: string | null; status?: Task['status'] }): Promise<Task> => {
+    // If worktreePath or baseDir is changing, kill old PTY and clear session so terminal starts fresh
+    if (data.worktreePath !== undefined || data.baseDir !== undefined) {
       const mainSessionId = `${data.id}:${data.id}`
       resetTaskState(mainSessionId)
       await window.api.pty.kill(mainSessionId)
       markSkipCache(mainSessionId)
+
+      // Clear conversation ID — the old session was in a different directory and can't be resumed
+      if (task) {
+        const cleared = await window.api.db.updateTask({
+          id: data.id,
+          providerConfig: setProviderConversationId(task.provider_config, task.terminal_mode, null)
+        })
+        handleTaskUpdate(cleared)
+      }
     }
 
     const updated = await window.api.db.updateTask(data)
     handleTaskUpdate(updated)
 
-    // Force terminal remount if worktreePath changed
-    if (data.worktreePath !== undefined) {
+    // Force terminal remount if cwd-affecting field changed
+    if (data.worktreePath !== undefined || data.baseDir !== undefined) {
       setTerminalKey(k => k + 1)
     }
 
     return updated
+  }
+
+  const handlePickBaseDir = async (): Promise<void> => {
+    if (!task) return
+    const result = await window.api.dialog.showOpenDialog({
+      title: 'Choose working directory',
+      defaultPath: task.base_dir || project?.path || undefined,
+      properties: ['openDirectory']
+    })
+    if (result.canceled || result.filePaths.length === 0) return
+    await updateTaskAndNotify({ id: task.id, baseDir: result.filePaths[0] })
+  }
+
+  const handleClearBaseDir = async (): Promise<void> => {
+    if (!task) return
+    await updateTaskAndNotify({ id: task.id, baseDir: null })
+  }
+
+  const handleDetachWorktree = async (): Promise<void> => {
+    if (!task) return
+    await updateTaskAndNotify({ id: task.id, worktreePath: null, worktreeParentBranch: null })
   }
 
   // Handler for browser tabs changes
@@ -1565,10 +1595,10 @@ export function TaskDetailPage({
               ) : project?.id === task.project_id && project.path && !projectPathMissing ? (
                 <TerminalContainer
                   ref={terminalContainerRef}
-                  key={`${terminalKey}-${task.project_id}-${project?.path || ''}-${task.worktree_path || ''}`}
+                  key={`${terminalKey}-${task.project_id}-${project?.path || ''}-${task.worktree_path || task.base_dir || ''}`}
                   taskId={task.id}
                   isActive={isActive}
-                  cwd={task.worktree_path || project.path}
+                  cwd={task.worktree_path || task.base_dir || project.path}
                   defaultMode={task.terminal_mode}
                   conversationId={getConversationIdForMode(task) || undefined}
                   existingConversationId={getConversationIdForMode(task) || undefined}
@@ -1583,6 +1613,7 @@ export function TaskDetailPage({
                   onRetry={handleRestartTerminal}
                   onFocusRequestHandled={handleTerminalFocusRequestHandled}
                   onMainTabActiveChange={setIsMainTabActive}
+                  onMainReset={handleResetTerminal}
                   rightContent={
                     <Tooltip open={!isMainTabActive && !task.is_temporary ? undefined : false}>
                       <TooltipTrigger asChild>
@@ -1842,7 +1873,7 @@ export function TaskDetailPage({
           <div data-panel-id="editor" className={cn("shrink-0 overflow-hidden rounded-md bg-surface-2 border border-border transition-shadow duration-200", multipleVisiblePanels && focusedPanel === 'editor' && "shadow-[0_0_18px_rgba(255,255,255,0.25)]")} style={{ width: resolvedWidths.editor }}>
             <FileEditorView
               ref={fileEditorRefCallback}
-              projectPath={task.worktree_path || project.path}
+              projectPath={task.worktree_path || task.base_dir || project.path}
               initialEditorState={task.editor_open_files}
               onEditorStateChange={handleEditorStateChange}
             />
@@ -2050,6 +2081,34 @@ export function TaskDetailPage({
             </div>
           </div>
 
+          {/* Working directory */}
+          <div className="flex flex-col gap-2">
+            <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">Working directory</span>
+            <div className="text-xs text-muted-foreground truncate px-2 py-1.5 rounded border border-border bg-muted/30" title={(task.worktree_path || task.base_dir || project?.path) ?? 'No directory set'}>
+              {(task.worktree_path || task.base_dir || project?.path) ?? 'No directory set'}
+              {task.worktree_path && <span className="ml-1 text-[10px] opacity-60">(worktree)</span>}
+              {!task.worktree_path && task.base_dir && <span className="ml-1 text-[10px] opacity-60">(custom)</span>}
+            </div>
+            <div className="flex items-center gap-2">
+              <Button variant="outline" size="sm" className="flex-1 text-xs justify-start" onClick={handlePickBaseDir}>
+                <FolderOpen className="mr-1.5 size-3" />
+                {task.base_dir ? 'Change directory' : 'Set custom directory'}
+              </Button>
+              {task.base_dir && (
+                <Button variant="outline" size="sm" className="text-xs" onClick={handleClearBaseDir}>
+                  <X className="mr-1.5 size-3" />
+                  Clear
+                </Button>
+              )}
+            </div>
+            {task.worktree_path && (
+              <Button variant="outline" size="sm" className="text-xs w-full justify-start" onClick={handleDetachWorktree}>
+                <GitBranch className="mr-1.5 size-3" />
+                Detach worktree (keep on disk)
+              </Button>
+            )}
+          </div>
+
         </div>
         )}
 
@@ -2068,7 +2127,7 @@ export function TaskDetailPage({
         {/* Processes Panel — dev mode only */}
         {import.meta.env.DEV && !compact && panelVisibility.processes && (
           <div data-panel-id="processes" className={cn("shrink-0 rounded-md bg-surface-2 border border-border overflow-hidden flex flex-col transition-shadow duration-200", multipleVisiblePanels && focusedPanel === 'processes' && "shadow-[0_0_18px_rgba(255,255,255,0.25)]")} style={{ width: resolvedWidths.processes }}>
-            <ProcessesPanel taskId={task.id} projectId={project?.id ?? null} cwd={task.worktree_path || project?.path} terminalSessionId={getMainSessionId(task.id)} />
+            <ProcessesPanel taskId={task.id} projectId={project?.id ?? null} cwd={task.worktree_path || task.base_dir || project?.path} terminalSessionId={getMainSessionId(task.id)} />
           </div>
         )}
       </div>
@@ -2077,7 +2136,7 @@ export function TaskDetailPage({
         <QuickOpenDialog
           open={quickOpenVisible}
           onOpenChange={setQuickOpenVisible}
-          projectPath={task.worktree_path || project.path}
+          projectPath={task.worktree_path || task.base_dir || project.path}
           onOpenFile={handleQuickOpenFile}
         />
       )}

--- a/packages/domains/task/src/main/handlers.ts
+++ b/packages/domains/task/src/main/handlers.ts
@@ -327,6 +327,7 @@ export function updateTask(db: Database, data: UpdateTaskInput): Task | null {
   }
   if (data.panelVisibility !== undefined) { fields.push('panel_visibility = ?'); values.push(data.panelVisibility ? JSON.stringify(data.panelVisibility) : null) }
   if (data.worktreePath !== undefined) { fields.push('worktree_path = ?'); values.push(data.worktreePath) }
+  if (data.baseDir !== undefined) { fields.push('base_dir = ?'); values.push(data.baseDir) }
   if (data.worktreeParentBranch !== undefined) { fields.push('worktree_parent_branch = ?'); values.push(data.worktreeParentBranch) }
   if (data.browserUrl !== undefined) { fields.push('browser_url = ?'); values.push(data.browserUrl) }
   if (data.browserTabs !== undefined) { fields.push('browser_tabs = ?'); values.push(data.browserTabs ? JSON.stringify(data.browserTabs) : null) }
@@ -499,7 +500,7 @@ export function registerTaskHandlers(ipcMain: IpcMain, db: Database): void {
     const childIds = (db.prepare('SELECT id FROM tasks WHERE parent_id = ? AND archived_at IS NULL').all(id) as { id: string }[]).map(r => r.id)
     for (const childId of childIds) { cleanupTaskFull(db, childId) }
     db.prepare(`
-      UPDATE tasks SET archived_at = datetime('now'), worktree_path = NULL, updated_at = datetime('now')
+      UPDATE tasks SET archived_at = datetime('now'), worktree_path = NULL, base_dir = NULL, updated_at = datetime('now')
       WHERE id = ? OR parent_id = ?
     `).run(id, id)
     const row = db.prepare('SELECT * FROM tasks WHERE id = ?').get(id) as Record<string, unknown> | undefined
@@ -518,7 +519,7 @@ export function registerTaskHandlers(ipcMain: IpcMain, db: Database): void {
     const allIds = [...ids, ...childIds]
     const placeholders = allIds.map(() => '?').join(',')
     db.prepare(`
-      UPDATE tasks SET archived_at = datetime('now'), worktree_path = NULL, updated_at = datetime('now')
+      UPDATE tasks SET archived_at = datetime('now'), worktree_path = NULL, base_dir = NULL, updated_at = datetime('now')
       WHERE id IN (${placeholders})
     `).run(...allIds)
   })

--- a/packages/domains/task/src/shared/types.ts
+++ b/packages/domains/task/src/shared/types.ts
@@ -163,6 +163,8 @@ export interface Task {
   // Worktree
   worktree_path: string | null
   worktree_parent_branch: string | null
+  // Custom working directory (overrides project.path, overridden by worktree_path)
+  base_dir: string | null
   browser_url: string | null
   // Browser tabs (JSON)
   browser_tabs: BrowserTabsState | null
@@ -235,6 +237,8 @@ export interface UpdateTaskInput {
   // Worktree
   worktreePath?: string | null
   worktreeParentBranch?: string | null
+  // Custom working directory
+  baseDir?: string | null
   browserUrl?: string | null
   // Browser tabs
   browserTabs?: BrowserTabsState | null

--- a/packages/domains/worktrees/src/client/GeneralTabContent.tsx
+++ b/packages/domains/worktrees/src/client/GeneralTabContent.tsx
@@ -51,7 +51,7 @@ export function GeneralTabContent({
   onTaskUpdated,
   onSwitchTab
 }: GeneralTabContentProps) {
-  const targetPath = task.worktree_path ?? projectPath
+  const targetPath = task.worktree_path ?? task.base_dir ?? projectPath
   const hasWorktree = !!task.worktree_path
 
   // Git status


### PR DESCRIPTION
## Summary

Adds a per-task custom working directory (`base_dir`) that overrides the project path without requiring a full git worktree. Priority chain: `worktree_path > base_dir > project.path`.

This is useful if a project setup doesn't match the expected one, or you for some reason want to to have a different context.

- New `base_dir` column on tasks (migration 55), cleared on archive
- "Working directory" section in task sidebar with pick/clear buttons
- Detach worktree button (keeps files on disk, just unlinks from task)
- Reset button on the main terminal tab to restart the session
- Changing `base_dir` kills the PTY session, clears conversation ID, and remounts the terminal so it starts fresh in the new directory
- All path references updated: terminal cwd, editor, quick open, git panel, processes panel

---

*Built with Claude Code w/ Opus 4.6*

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a per-task custom working directory (`base_dir`) that slots into an existing priority chain (`worktree_path > base_dir > project.path`). The feature is well-scoped: it adds a DB migration, propagates the new field through types and the update handler, wires the priority chain into all existing path consumers (terminal `cwd`, editor, quick-open, git panel, processes panel), and exposes pick/clear/detach buttons in the task sidebar. A "Reset" button is also added to the main terminal tab to manually restart the session.

**Key concerns:**
- **Logic bug**: When a task already has an active `worktree_path`, calling `updateTaskAndNotify` with `baseDir` set kills the PTY and clears the conversation ID even though the effective working directory (still `worktree_path`) hasn't actually changed. This destroys a user's running terminal session unnecessarily.
- **UX**: The reset button on the main tab uses an `X` icon, which reads as "close" rather than "reset", risking accidental misunderstanding of the button's destructive action.

The migration, type definitions, handler, and path consumer updates are all correct. The architecture and approach are sound.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

- Safe to merge after fixing the logic bug where setting `base_dir` while a worktree is active unnecessarily kills the PTY session, and replacing the reset button icon with a clearer visual indicator.
- The migration, type definitions, handler, and path consumer updates are all correct and architecturally sound. The main concern is a logic bug in `updateTaskAndNotify` that triggers destructive PTY/session resets even when the effective working directory hasn't changed (worktree is active). This can silently destroy a user's running terminal session. The icon choice for the reset button is a secondary UX concern that could prevent user confusion. Both issues should be addressed before merge.
- packages/domains/task/src/client/TaskDetailPage.tsx — logic bug in `updateTaskAndNotify`; packages/domains/task-terminals/src/client/TerminalTabBar.tsx — icon choice for reset button
</details>

<sub>Last reviewed commit: 4bfcdc2</sub>

> Greptile also left **2 inline comments** on this PR.

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->