### PR TITLE
fix(worktrees): handle already-deleted worktree path in removeWorktree

### DIFF
--- a/packages/domains/worktrees/src/main/git-worktree.ts
+++ b/packages/domains/worktrees/src/main/git-worktree.ts
@@ -353,7 +353,15 @@ export function runWorktreeSetupScriptSync(
 }
 
 export function removeWorktree(repoPath: string, worktreePath: string): void {
-  spawnGit(['worktree', 'remove', worktreePath, '--force'], { cwd: repoPath })
+  try {
+    spawnGit(['worktree', 'remove', worktreePath, '--force'], { cwd: repoPath })
+  } catch (err) {
+    if (!existsSync(worktreePath)) {
+      spawnGit(['worktree', 'prune'], { cwd: repoPath })
+      return
+    }
+    throw err
+  }
 }
 
 export function initRepo(path: string): void {


### PR DESCRIPTION
## Summary

`removeWorktree` throws when the worktree directory has already been deleted from disk (e.g. manually or by another tool). Now catches the error, checks if the path is gone, and falls back to `git worktree prune` to clean up the stale reference.

---

*Built with Claude Code w/ Opus 4.6*

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR safely hardens `removeWorktree` to gracefully handle the case where a worktree directory has already been deleted from disk (e.g., manually or by an external tool) before `git worktree remove` is called. The fix wraps the existing `spawnGit` call in a try/catch, checks for the missing path with `existsSync`, and falls back to `git worktree prune` to clean up the stale git reference.

- The happy path is unchanged; the new try/catch only activates on failure.
- `existsSync` is already imported at the top of the file, so no new dependencies are introduced.
- The fallback correctly handles the primary scenario: path deleted externally → `git worktree remove --force` throws → path confirmed absent → `git worktree prune` cleans the stale git entry.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge. This is a narrow, additive error-handling fix with no changes to the happy path.
- This PR is a straightforward fix for a real scenario (worktree directory deleted externally before removal). The implementation is correct: it catches the error, verifies the path is gone, and uses the appropriate git cleanup command. The change is small, well-scoped, and introduces no new dependencies. No tests are included, but the function is a thin wrapper around git commands.
- No files require special attention.
</details>

<sub>Last reviewed commit: 935968d</sub>

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->