### PR TITLE
fix(terminal): add Ctrl+Shift+C/V for copy/paste on Linux

### DIFF
--- a/packages/domains/terminal/src/client/Terminal.tsx
+++ b/packages/domains/terminal/src/client/Terminal.tsx
@@ -190,6 +190,11 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
       void clearBufferWithoutRestart()
       return false
     }
+    // Ctrl+Shift+C/V handled via DOM keydown listener (useEffect below)
+    // to work reliably regardless of xterm.js internal event handling.
+    if (e.ctrlKey && e.shiftKey && (e.code === 'KeyC' || e.code === 'KeyV') && e.type === 'keydown') {
+      return false
+    }
     return true
   }, [clearBufferWithoutRestart])
 
@@ -622,6 +627,36 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
     if (!t) return
     t.options.scrollback = terminalScrollback
   }, [terminalScrollback])
+
+  // Handle Ctrl+Shift+C/V at the DOM level for reliable copy/paste on Linux/Windows.
+  // Uses a capture-phase listener on the container so it fires before xterm.js
+  // processes the key event. macOS uses Cmd+C/V natively via xterm.js.
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    const handleCopyPaste = (e: KeyboardEvent): void => {
+      if (!e.ctrlKey || !e.shiftKey) return
+
+      if (e.code === 'KeyC') {
+        e.preventDefault()
+        e.stopPropagation()
+        const sel = terminalRef.current?.getSelection()
+        if (sel) void navigator.clipboard.writeText(sel)
+      }
+
+      if (e.code === 'KeyV') {
+        e.preventDefault()
+        e.stopPropagation()
+        void navigator.clipboard.readText().then((text) => {
+          if (text) window.api.pty.write(sessionId, text)
+        })
+      }
+    }
+
+    container.addEventListener('keydown', handleCopyPaste, true)
+    return () => container.removeEventListener('keydown', handleCopyPaste, true)
+  }, [sessionId])
 
   // Handle paste and drag-drop for files/images
   useEffect(() => {


### PR DESCRIPTION
## Summary

- xterm.js leaves copy/paste keybinding to the integrating app — on Linux/Windows, there was no way to copy selected terminal text or paste from clipboard
- Intercept **Ctrl+Shift+C** to copy selection and **Ctrl+Shift+V** to paste in the terminal's custom key event handler
- No impact on macOS where Cmd+C/V already works natively

## Test plan

- [ ] On Linux: select text in terminal → Ctrl+Shift+C → paste in another app to verify
- [ ] On Linux: copy text elsewhere → Ctrl+Shift+V in terminal → verify it's written to the PTY
- [ ] On macOS: verify Cmd+C/V still works as before
- [ ] Verify Ctrl+C (without Shift) still sends SIGINT

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds Ctrl+Shift+C / Ctrl+Shift+V copy-paste support to the embedded xterm.js terminal for Linux and Windows users. It works by registering a DOM capture-phase `keydown` listener on the terminal container so it fires before xterm.js processes the key, and by returning `false` from xterm.js's `attachCustomKeyEventHandler` for those combos as a belt-and-suspenders guard.

**Key changes:**
- New `useEffect` (line 634–659) attaches a capture-phase `keydown` listener that calls `navigator.clipboard.writeText` / `readText` and forwards pasted text to `window.api.pty.write`.
- `handleTerminalKeyEvent` extended (line 195–197) to return `false` for `Ctrl+Shift+C/V`, preventing xterm.js from acting on them.

**Issues found:**
- For the copy path, `e.preventDefault()` and `e.stopPropagation()` are called before checking whether any text is actually selected; when nothing is selected the key event is silently consumed with no user feedback.

The core approach (capture-phase DOM listener + xterm.js handler returning false) is sound and well-contained to one file.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

- Safe to merge with minor UX refinement — the copy/paste feature works correctly on Linux/Windows with no regressions.
- The core implementation is architecturally sound and well-contained. The identified issue is a UX gap (silent event consumption when nothing is selected) rather than a functional bug or regression. No crashes, data loss, or security concerns.
- packages/domains/terminal/src/client/Terminal.tsx — the copy handler should check for a selection before consuming the event.
</details>

<sub>Last reviewed commit: 7d1ff27</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->