### PR TITLE
fix(release): remove duplicate releaseDate in merged update manifest

### DIFF
--- a/scripts/release/merge-update-manifest.mjs
+++ b/scripts/release/merge-update-manifest.mjs
@@ -76,7 +76,7 @@ function parseManifest(text) {
 function serializeManifest(top, files) {
   let out = ''
   for (const [k, v] of Object.entries(top)) {
-    if (k === 'path' || k === 'sha512') continue
+    if (k === 'path' || k === 'sha512' || k === 'releaseDate') continue
     out += `${k}: ${v}\n`
   }
   out += 'files:\n'


### PR DESCRIPTION
Since there is multiple architecture build on macos, releaseDate was written twice in the serialized output — once during the top-level key loop and again explicitly at the end. Skip it in the loop so it only appears once. (c.f. https://github.com/debuglebowski/slayzone/releases/download/v0.3.0/latest-mac.yml)

This produce an issue on macos when opening the app

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a duplicate `releaseDate` key in the serialized macOS auto-update manifest produced by `scripts/release/merge-update-manifest.mjs`. When multiple architecture builds (e.g. `x64` and `arm64`) are merged for macOS, the `serializeManifest` function emitted `releaseDate` twice — once during the top-level key loop and again explicitly at the end of the function (lines 93-95). The fix adds `releaseDate` to the existing skip-condition in the loop alongside the already-skipped `path` and `sha512` keys, which are likewise emitted explicitly later. This matches the expected behavior for the other two skipped keys and resolves the malformed YAML that prevented the app from opening on macOS.

**Changes:**
- `scripts/release/merge-update-manifest.mjs`: One-line change — `k === 'releaseDate'` added to the `continue` guard in `serializeManifest`, preventing the duplicate top-level `releaseDate` entry in the merged manifest.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

- This PR is safe to merge — it is a minimal, targeted one-line bug fix with no side effects.
- The change exactly mirrors the pattern already used for `path` and `sha512` (skip in loop, emit explicitly later) and is confirmed correct by reading the full serialization logic. No new code paths, no tests broken, no behavioral change except removing the duplicate key.
- No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/release/merge-update-manifest.mjs | Adds `releaseDate` to the skip-list inside the serialization loop so the field is only emitted once (explicitly at line 93-95), eliminating the duplicate key that broke macOS auto-update parsing. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[serializeManifest called] --> B["Loop over Object.entries(top)"]
    B --> C{k === 'path'\nOR k === 'sha512'\nOR k === 'releaseDate'?}
    C -- Yes --> D[skip — continue]
    C -- No --> E["Emit: k: v\n"]
    D --> B
    E --> B
    B -- done --> F["Emit: files: block"]
    F --> G[Loop over each file entry]
    G --> H["Emit per-file path/sha512/size/url"]
    H --> G
    G -- done --> I["Emit: path: files[0].url"]
    I --> J["Emit: sha512: files[0].sha512"]
    J --> K{top.releaseDate\nexists?}
    K -- Yes --> L["Emit: releaseDate: top.releaseDate\n(once, here only)"]
    K -- No --> M[return output string]
    L --> M
```
</details>

<sub>Last reviewed commit: 73e242f</sub>

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->