### PR TITLE
fix(editor): fix compact line spacing not working with Milkdown

### DIFF
--- a/packages/apps/app/src/renderer/src/assets/main.css
+++ b/packages/apps/app/src/renderer/src/assets/main.css
@@ -347,29 +347,29 @@
 }
 
 /* Compact line spacing for notes editor */
-.prose-tight .ProseMirror.prose > * + * {
+.prose-tight .ProseMirror > * + * {
   margin-top: 0.125em;
 }
 
-.prose-tight .ProseMirror.prose p {
-  margin-top: 0.125em;
-  margin-bottom: 0.125em;
-}
-
-.prose-tight .ProseMirror.prose ul,
-.prose-tight .ProseMirror.prose ol {
+.prose-tight .ProseMirror p {
   margin-top: 0.125em;
   margin-bottom: 0.125em;
 }
 
-.prose-tight .ProseMirror.prose li {
+.prose-tight .ProseMirror ul,
+.prose-tight .ProseMirror ol {
+  margin-top: 0.125em;
+  margin-bottom: 0.125em;
+}
+
+.prose-tight .ProseMirror li {
   margin-top: 0;
   margin-bottom: 0;
 }
 
-.prose-tight .ProseMirror.prose h1,
-.prose-tight .ProseMirror.prose h2,
-.prose-tight .ProseMirror.prose h3 {
+.prose-tight .ProseMirror h1,
+.prose-tight .ProseMirror h2,
+.prose-tight .ProseMirror h3 {
   margin-top: 0.375em;
   margin-bottom: 0.125em;
 }


### PR DESCRIPTION
## Summary
- Compact line spacing setting (Settings > Appearance > Line spacing) had no effect after the TipTap-to-Milkdown editor migration
- The CSS selectors targeted `.ProseMirror.prose` but Milkdown renders `.ProseMirror` as a separate element without the `prose` class (`.prose` is on a parent div)
- Removed `.prose` from all compact spacing selectors so they match `.prose-tight .ProseMirror`

## Test plan
- [ ] Open Settings > Appearance, set Line spacing to "Compact"
- [ ] Open a task description with multiple paragraphs and list items
- [ ] Verify spacing is visibly tighter than "Normal" mode
- [ ] Switch back to "Normal" — spacing should return to default

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes compact line spacing not applying in the Milkdown editor by removing the `.prose` class co-requirement from all five `prose-tight` CSS selector groups. After the TipTap→Milkdown migration, `.ProseMirror` no longer carries the `.prose` class, so the old `.prose-tight .ProseMirror.prose` selectors never matched Milkdown's DOM structure.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — minimal, targeted CSS fix with no logic changes

Single-file CSS change that broadens five selector groups from requiring .ProseMirror.prose to .ProseMirror. Fix is correct, well-scoped, and no P0/P1 issues found. All other .ProseMirror.prose selectors (editor-themed theming) are correctly left untouched.

No files require special attention
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/apps/app/src/renderer/src/assets/main.css | Removes .prose class qualifier from 5 compact-spacing selector groups so they match Milkdown's .ProseMirror (which no longer carries .prose after TipTap migration) |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User sets Line Spacing: Compact] --> B[prose-tight class added to editor container]
    B --> C{Which editor?}
    C -->|TipTap| D[".ProseMirror.prose element"]
    C -->|Milkdown| E[".ProseMirror element\n.prose on parent div"]
    D --> F["OLD: .prose-tight .ProseMirror.prose ✓\nNEW: .prose-tight .ProseMirror ✓"]
    E --> G["OLD: .prose-tight .ProseMirror.prose ✗\nNEW: .prose-tight .ProseMirror ✓"]
    F --> H[Compact spacing applied]
    G --> H
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(editor): fix compact line spacing no..."](https://github.com/debuglebowski/slayzone/commit/e2149e73507b1623eb0f01d2478bdace84c758fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27563838)</sub>

<!-- /greptile_comment -->