### PR TITLE
feat(browser): hide panel on last tab close, Cmd+T new tab

### DIFF
--- a/packages/domains/task-browser/src/client/BrowserPanel.tsx
+++ b/packages/domains/task-browser/src/client/BrowserPanel.tsx
@@ -90,6 +90,7 @@ interface BrowserPanelProps {
   className?: string
   tabs: BrowserTabsState
   onTabsChange: (tabs: BrowserTabsState) => void
+  onRequestHide?: () => void
   taskId?: string
   projectId?: string
   isResizing?: boolean
@@ -355,6 +356,7 @@ export const BrowserPanel = forwardRef<BrowserPanelHandle, BrowserPanelProps>(fu
   className,
   tabs,
   onTabsChange,
+  onRequestHide,
   taskId,
   projectId,
   isResizing,
@@ -651,9 +653,9 @@ export const BrowserPanel = forwardRef<BrowserPanelHandle, BrowserPanelProps>(fu
     let newActiveId = tabs.activeTabId
     if (tabId === tabs.activeTabId) {
       if (newTabs.length === 0) {
-        const newTab: BrowserTab = { id: generateTabId(), url: newTabUrl, title: newTabUrl === 'about:blank' ? 'New Tab' : newTabUrl }
-        onTabsChange({ tabs: [newTab], activeTabId: newTab.id })
+        onTabsChange({ tabs: [], activeTabId: null })
         track('browser_tab_closed')
+        onRequestHide?.()
         return
       }
       newActiveId = newTabs[Math.min(idx, newTabs.length - 1)]?.id || null
@@ -661,7 +663,7 @@ export const BrowserPanel = forwardRef<BrowserPanelHandle, BrowserPanelProps>(fu
 
     onTabsChange({ tabs: newTabs, activeTabId: newActiveId })
     track('browser_tab_closed')
-  }, [tabs, onTabsChange, newTabUrl])
+  }, [tabs, onTabsChange, onRequestHide, newTabUrl])
 
   const switchToTab = useCallback((tabId: string) => {
     onTabsChange({ ...tabs, activeTabId: tabId })

--- a/packages/domains/task-browser/src/client/BrowserPanel.tsx
+++ b/packages/domains/task-browser/src/client/BrowserPanel.tsx
@@ -663,7 +663,7 @@ export const BrowserPanel = forwardRef<BrowserPanelHandle, BrowserPanelProps>(fu
 
     onTabsChange({ tabs: newTabs, activeTabId: newActiveId })
     track('browser_tab_closed')
-  }, [tabs, onTabsChange, onRequestHide, newTabUrl])
+  }, [tabs, onTabsChange, onRequestHide])
 
   const switchToTab = useCallback((tabId: string) => {
     onTabsChange({ ...tabs, activeTabId: tabId })

--- a/packages/domains/task-terminals/src/client/TerminalContainer.tsx
+++ b/packages/domains/task-terminals/src/client/TerminalContainer.tsx
@@ -146,8 +146,10 @@ export const TerminalContainer = forwardRef<TerminalContainerHandle, TerminalCon
 
     const handleKeyDown = withModalGuard((e: KeyboardEvent) => {
       if (useShortcutStore.getState().isRecording) return
-      // New group
+      // New group (skip when browser panel is focused — Cmd+T creates a browser tab instead)
       if (matchesShortcut(e, useShortcutStore.getState().getKeys('terminal-new-group'))) {
+        const target = document.activeElement as HTMLElement | null
+        if (target?.closest('[data-browser-panel]')) return
         e.preventDefault()
         pendingFocusRef.current = true
         createTab()

--- a/packages/domains/task/src/client/TaskDetailPage.tsx
+++ b/packages/domains/task/src/client/TaskDetailPage.tsx
@@ -768,6 +768,7 @@ export const TaskDetailPage = React.memo(function TaskDetailPage({
   const [focusedPanel, setFocusedPanel] = useState<string | null>(null)
   const onCloseTabRef = useRef(onCloseTab)
   onCloseTabRef.current = onCloseTab
+  const handlePanelToggleRef = useRef<typeof handlePanelToggle>(null!)
   useEffect(() => {
     const handleFocusIn = (e: FocusEvent): void => {
       const target = e.target as HTMLElement | null
@@ -817,7 +818,7 @@ export const TaskDetailPage = React.memo(function TaskDetailPage({
           return
         } else if (bt.tabs.length === 1) {
           setBrowserTabs({ tabs: [], activeTabId: null })
-          setPanelVisibility(prev => ({ ...prev, browser: false }))
+          handlePanelToggleRef.current('browser', false)
           return
         }
       }
@@ -961,6 +962,7 @@ export const TaskDetailPage = React.memo(function TaskDetailPage({
     },
     [task, panelVisibility, onTaskUpdated, resetPanelSize]
   )
+  handlePanelToggleRef.current = handlePanelToggle
 
   const handleQuickOpenFile = useCallback((filePath: string, options?: OpenFileOptions) => {
     if (fileEditorRef.current) {

--- a/packages/domains/task/src/client/TaskDetailPage.tsx
+++ b/packages/domains/task/src/client/TaskDetailPage.tsx
@@ -817,7 +817,7 @@ export const TaskDetailPage = React.memo(function TaskDetailPage({
           return
         } else if (bt.tabs.length === 1) {
           setBrowserTabs({ tabs: [], activeTabId: null })
-          handlePanelToggle('browser', false)
+          setPanelVisibility(prev => ({ ...prev, browser: false }))
           return
         }
       }
@@ -1042,15 +1042,16 @@ export const TaskDetailPage = React.memo(function TaskDetailPage({
         return
       }
       if (matchesShortcut(e, keys('panel-terminal'))) {
-        e.preventDefault()
         // Cmd+T opens a new browser tab when browser panel is focused
         if (lastFocusedPanelRef.current === 'browser' && panelVisibility.browser && isBuiltinEnabled('browser', 'task')) {
+          e.preventDefault()
           const newTab = { id: `tab-${crypto.randomUUID().slice(0, 8)}`, url: 'about:blank', title: 'New Tab' }
           setBrowserTabs(prev => ({ tabs: [...prev.tabs, newTab], activeTabId: newTab.id }))
           requestAnimationFrame(() => browserPanelRef.current?.focusUrlBar())
           return
         }
         if (isBuiltinEnabled('terminal', 'task')) {
+          e.preventDefault()
           handlePanelToggle('terminal', !panelVisibility.terminal)
         }
         return

--- a/packages/domains/task/src/client/TaskDetailPage.tsx
+++ b/packages/domains/task/src/client/TaskDetailPage.tsx
@@ -815,6 +815,10 @@ export const TaskDetailPage = React.memo(function TaskDetailPage({
           const newActiveId = newTabs[Math.min(idx, newTabs.length - 1)]?.id ?? null
           setBrowserTabs({ tabs: newTabs, activeTabId: newActiveId })
           return
+        } else if (bt.tabs.length === 1) {
+          setBrowserTabs({ tabs: [], activeTabId: null })
+          handlePanelToggle('browser', false)
+          return
         }
       }
       // Nothing was closed — close the task tab
@@ -941,6 +945,11 @@ export const TaskDetailPage = React.memo(function TaskDetailPage({
       setPanelVisibility(newVisibility)
       // Auto-focus panel content so scope tracker detects the right scope
       if (panelId === 'browser' && active) {
+        // Create a fresh tab when reopening with no tabs
+        if (browserTabs.tabs.length === 0) {
+          const newTab = { id: `tab-${crypto.randomUUID().slice(0, 8)}`, url: 'about:blank', title: 'New Tab' }
+          setBrowserTabs({ tabs: [newTab], activeTabId: newTab.id })
+        }
         requestAnimationFrame(() => browserPanelRef.current?.focus())
       }
       // Persist to DB
@@ -1032,9 +1041,18 @@ export const TaskDetailPage = React.memo(function TaskDetailPage({
         }
         return
       }
-      if (matchesShortcut(e, keys('panel-terminal')) && isBuiltinEnabled('terminal', 'task')) {
+      if (matchesShortcut(e, keys('panel-terminal'))) {
         e.preventDefault()
-        handlePanelToggle('terminal', !panelVisibility.terminal)
+        // Cmd+T opens a new browser tab when browser panel is focused
+        if (lastFocusedPanelRef.current === 'browser' && panelVisibility.browser && isBuiltinEnabled('browser', 'task')) {
+          const newTab = { id: `tab-${crypto.randomUUID().slice(0, 8)}`, url: 'about:blank', title: 'New Tab' }
+          setBrowserTabs(prev => ({ tabs: [...prev.tabs, newTab], activeTabId: newTab.id }))
+          requestAnimationFrame(() => browserPanelRef.current?.focusUrlBar())
+          return
+        }
+        if (isBuiltinEnabled('terminal', 'task')) {
+          handlePanelToggle('terminal', !panelVisibility.terminal)
+        }
         return
       }
       if (matchesShortcut(e, keys('panel-processes')) && isBuiltinEnabled('processes', 'task')) {
@@ -1989,6 +2007,7 @@ export const TaskDetailPage = React.memo(function TaskDetailPage({
               className="h-full"
               tabs={browserTabs}
               onTabsChange={handleBrowserTabsChange}
+              onRequestHide={() => handlePanelToggle('browser', false)}
               taskId={task.id}
               projectId={task.project_id}
               isResizing={isResizing}


### PR DESCRIPTION
## Summary

- **Closing the last browser tab now hides the browser panel.** Previously, closing the last tab would silently create a new blank tab, making it impossible to dismiss the panel by closing tabs. Now the panel hides — both via the close button (mouse) and via Cmd+W. Reopening the panel later creates a fresh blank tab automatically.
- **Cmd+T creates a new browser tab when the browser panel is focused.** Previously Cmd+T always toggled the terminal panel regardless of context. Now it behaves like a standard browser: if the browser panel has focus, Cmd+T opens a new tab and focuses the URL bar. When any other panel is focused, Cmd+T toggles the terminal as before.

## Video

https://github.com/user-attachments/assets/cca9df30-6c0c-40b6-9ab9-97aacaace3e5



## Test plan

- [x] Open browser panel, open multiple tabs, close them one by one — panel should hide when the last tab is closed
- [x] Repeat using Cmd+W instead of the mouse close button — same behavior
- [x] After the panel hides, reopen it (Cmd+B) — should show a fresh blank tab
- [x] Focus the browser panel, press Cmd+T — should create a new browser tab and focus the URL bar
- [x] Focus the terminal panel, press Cmd+T — should toggle the terminal panel as before
- [x] Verify Cmd+W on the last tab does not close the task tab (it hides the browser panel instead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR implements two UX improvements: closing the last browser tab now hides the browser panel (instead of silently creating a new blank tab), and Cmd+T creates a browser tab when the browser panel is focused rather than always toggling the terminal. The four issues flagged in prior review rounds (stale `handlePanelToggle` closure, unconditional `e.preventDefault()`, unused `newTabUrl` dep, DB persistence bypass) are all addressed in this revision via the `handlePanelToggleRef` pattern and conditional `preventDefault` placement.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all previously flagged P1 issues are resolved and remaining findings are minor style improvements.

The four P1 concerns from prior review rounds (stale closure, unconditional preventDefault, unused dep, DB persistence bypass) are all addressed. The three remaining comments are P2: a latent stale-read risk that is safe under current React 18 batching, an inconsistency between the two Cmd+T guards in an edge-case native-menu code path, and an unstable inline callback reference. None block correctness.

packages/domains/task/src/client/TaskDetailPage.tsx — minor browserTabsRef and callback stability suggestions; packages/domains/task-terminals/src/client/TerminalContainer.tsx — native-menu edge case for the activeElement guard.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/domains/task/src/client/TaskDetailPage.tsx | Adds handlePanelToggleRef to fix stale-closure issues in the Cmd+W handler, new-tab logic on browser reopen, and Cmd+T browser-tab creation; browserTabs is captured in handlePanelToggle without being in its dep array (safe due to batching, but fragile). |
| packages/domains/task-browser/src/client/BrowserPanel.tsx | closeTab now calls onRequestHide when the last tab is closed and clears tabs state; dependency array correctly updated from newTabUrl to onRequestHide. |
| packages/domains/task-terminals/src/client/TerminalContainer.tsx | Adds a document.activeElement guard to skip creating a terminal group when the browser panel is focused; uses a different mechanism than the sticky lastFocusedPanelRef used in TaskDetailPage. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/domains/task/src/client/TaskDetailPage.tsx
Line: 950-952

Comment:
**`browserTabs` not in `handlePanelToggle`'s dep array**

`browserTabs` is read at line 950 but is absent from `handlePanelToggle`'s dep array (`[task, panelVisibility, onTaskUpdated, resetPanelSize]`). In practice React 18 batching ensures the closure is refreshed (closing the last tab and hiding the panel are batched into a single render that also recreates this callback), but the omission leaves a latent stale-read risk if the call graph ever changes. A `setBrowserTabs` functional update or a `browserTabsRef` (already present on line 763) would remove the dependency entirely.

```suggestion
        if (browserTabsRef.current.tabs.length === 0) {
          const newTab = { id: `tab-${crypto.randomUUID().slice(0, 8)}`, url: 'about:blank', title: 'New Tab' }
          setBrowserTabs({ tabs: [newTab], activeTabId: newTab.id })
        }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/domains/task-terminals/src/client/TerminalContainer.tsx
Line: 151-152

Comment:
**`document.activeElement` guard vs. the sticky `lastFocusedPanelRef` in `TaskDetailPage`**

`TaskDetailPage` notes (line 766) that *"macOS native menu accelerators clear activeElement by callback time"* — that's why it uses a sticky `lastFocusedPanelRef`. This guard uses `document.activeElement` instead, so when Cmd+T arrives via the native menu bar (not a raw key press), `activeElement` may already be null and the guard will not fire. In that edge case `TerminalContainer` would proceed to call `createTab()` while `TaskDetailPage` simultaneously creates a browser tab, resulting in both actions running at once. For a keyboard-triggered shortcut this is fine; it's only a risk for the native-menu path. Consider passing `lastFocusedPanelRef` (or a derived `isBrowserFocused` prop/store value) down to `TerminalContainer` so both handlers use the same source of truth.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/domains/task/src/client/TaskDetailPage.tsx
Line: 2013

Comment:
**Inline arrow for `onRequestHide` recreates on every render**

`() => handlePanelToggle('browser', false)` allocates a new function reference on every parent render. `BrowserPanel.closeTab` lists `onRequestHide` in its `useCallback` deps, so it is also recreated on every render of `TaskDetailPage`. Wrapping with `useCallback` (or reusing `handlePanelToggle` directly since the panel ID is fixed) would keep the reference stable.

Or hoist it as a named callback near `handlePanelToggle`.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: persist panel visibility to DB on C..."](https://github.com/debuglebowski/slayzone/commit/e1a89c97c50e9dd6bf74d1b50548982a9befc6b3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27991762)</sub>

<!-- /greptile_comment -->