### PR TITLE
fix(db): prevent esbuild from mangling datetime('now') in SQL

### DIFF
--- a/packages/domains/ai-config/src/main/handlers-marketplace.ts
+++ b/packages/domains/ai-config/src/main/handlers-marketplace.ts
@@ -118,7 +118,7 @@ export function registerMarketplaceHandlers(ipcMain: IpcMain, db: Database): voi
   })
 
   ipcMain.handle('ai-config:marketplace:toggle-registry', (_event, registryId: string, enabled: boolean) => {
-    db.prepare(`UPDATE skill_registries SET enabled = ?, updated_at = datetime('now') WHERE id = ?`)
+    db.prepare("UPDATE skill_registries SET enabled = ?, updated_at = datetime('now') WHERE id = ?")
       .run(enabled ? 1 : 0, registryId)
   })
 
@@ -453,7 +453,7 @@ function seedBuiltinEntries(db: Database): void {
         installedVersion: item.content_hash,
         installedAt: new Date().toISOString()
       }
-      db.prepare(`UPDATE ai_config_items SET content = ?, metadata_json = ?, updated_at = datetime('now') WHERE id = ?`)
+      db.prepare("UPDATE ai_config_items SET content = ?, metadata_json = ?, updated_at = datetime('now') WHERE id = ?")
         .run(normalized.content, JSON.stringify(meta), item.item_id)
     }
   })()


### PR DESCRIPTION
## Summary
- esbuild converts simple template literals to single-quoted strings, flipping `datetime('now')` into `datetime("now")`
- SQLite treats `"now"` as a column identifier → crash on startup
- Changed 2 template literals to double-quoted JS strings so inner single quotes survive the build

Fixes #67

## Test plan
- [x] Verified compiled output no longer contains `datetime("now")`
- [ ] `pnpm build && pnpm start` — app launches without SQLite error

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a startup crash by converting two single-line template literals in `handlers-marketplace.ts` that contain `datetime('now')` to double-quoted JS strings, preventing esbuild from swapping the inner single quotes to double quotes during compilation (which caused SQLite to interpret `"now"` as a column identifier rather than a string literal).

The remaining `datetime('now')` usages in the same file are all inside genuine multi-line template literals, which esbuild cannot collapse to single-quoted strings, so they are unaffected.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — targeted fix with no logic changes and no remaining P0/P1 issues.

The two changed lines are a straightforward quote style fix; the SQL semantics are identical. The multi-line template literals retaining datetime('now') are unaffected because esbuild cannot represent newline-containing strings as single-quoted literals. Other production files in the codebase already follow the same correct patterns. No P0 or P1 findings.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/domains/ai-config/src/main/handlers-marketplace.ts | Two single-line template literals with datetime('now') converted to double-quoted JS strings (lines 121, 456); remaining datetime('now') usages are in multi-line template literals that esbuild cannot mangle. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Source: template literal with datetime now] --> B{esbuild bundler}
    B -- Before fix single-line --> C[Output: inner single quotes flipped to double quotes]
    B -- After fix double-quoted JS string --> D[Output: inner single quotes preserved]
    C --> E[SQLite treats now as column identifier - CRASH]
    D --> F[SQLite treats now as string literal - OK]
    G[Multi-line template literals lines 342 382 401] --> H{esbuild bundler}
    H --> I[Cannot collapse - contains real newlines - Safe unchanged]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(db): use double-quoted strings for S..."](https://github.com/debuglebowski/slayzone/commit/6a51b44b65041215af71192ee14d431a52568d77) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28084408)</sub>

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->