### PR TITLE
feat: floating agent panel — auto-detach on window blur

### DIFF
--- a/packages/apps/app/src/main/floating-agent.ts
+++ b/packages/apps/app/src/main/floating-agent.ts
@@ -1,0 +1,296 @@
+import { BrowserWindow, ipcMain, screen, globalShortcut, app } from 'electron'
+import { join } from 'path'
+import { is } from '@electron-toolkit/utils'
+import { redirectSessionWindow, getBufferSince } from '@slayzone/terminal/main'
+import { toElectronAccelerator, shortcutDefinitions } from '@slayzone/shortcuts'
+import { getDatabase } from './db'
+
+// --- Types ---
+
+type AnchorPosition = 'bottom-right' | 'bottom-left' | 'top-right' | 'top-left' | 'center-bottom' | 'center-left' | 'center-right'
+type WidgetStyle = 'widget' | 'icon'
+
+interface FloatingAgentConfig {
+  style: WidgetStyle
+  position: AnchorPosition
+}
+
+// --- Constants ---
+
+const DEFAULT_CONFIG: FloatingAgentConfig = { style: 'widget', position: 'bottom-right' }
+const COLLAPSED_WIDTH = 138
+const COLLAPSED_HEIGHT = 52
+const COLLAPSED_ICON_SIZE = 44
+const EXPANDED_WIDTH = 360
+const EXPANDED_HEIGHT_RATIO = 0.5
+const MARGIN = 0
+
+// --- Shortcut ---
+
+let registeredAccelerator: string | null = null
+let getShortcutOverrides: () => Record<string, string> = () => ({})
+
+function getAgentPanelAccelerator(): string | null {
+  const overrides = getShortcutOverrides()
+  const keys = overrides['agent-panel'] || shortcutDefinitions.find(d => d.id === 'agent-panel')?.defaultKeys
+  if (!keys) return null
+  return toElectronAccelerator(keys)
+}
+
+function registerFloatingShortcut(): void {
+  unregisterFloatingShortcut()
+  const accel = getAgentPanelAccelerator()
+  if (!accel) return
+  const ok = globalShortcut.register(accel, () => {
+    if (floatingDetached) toggleCollapse()
+  })
+  if (ok) registeredAccelerator = accel
+}
+
+function unregisterFloatingShortcut(): void {
+  if (registeredAccelerator) {
+    globalShortcut.unregister(registeredAccelerator)
+    registeredAccelerator = null
+  }
+}
+
+// --- State ---
+
+let mainWindow: BrowserWindow | null = null
+let floatingAgentWindow: BrowserWindow | null = null
+let floatingBlurDebounce: ReturnType<typeof setTimeout> | null = null
+let blurCursorPoint: Electron.Point | null = null
+let lastDetachTime = 0
+let currentFloatingSession: { sessionId: string; cwd: string; mode: string } | null = null
+let floatingDetached = false
+let isCollapsed = true
+let currentConfig: FloatingAgentConfig = DEFAULT_CONFIG
+let displayFollowInterval: ReturnType<typeof setInterval> | null = null
+let lastDisplayId: number | null = null
+
+// --- Anchor Math ---
+
+function calcBounds(
+  workArea: Electron.Rectangle,
+  position: AnchorPosition,
+  widgetWidth: number,
+  widgetHeight: number
+): Electron.Rectangle {
+  const { x, y, width: w, height: h } = workArea
+  const m = MARGIN
+  switch (position) {
+    case 'bottom-right':  return { x: x + w - widgetWidth - m, y: y + h - widgetHeight - m, width: widgetWidth, height: widgetHeight }
+    case 'bottom-left':   return { x: x + m, y: y + h - widgetHeight - m, width: widgetWidth, height: widgetHeight }
+    case 'top-right':     return { x: x + w - widgetWidth - m, y: y + m, width: widgetWidth, height: widgetHeight }
+    case 'top-left':      return { x: x + m, y: y + m, width: widgetWidth, height: widgetHeight }
+    case 'center-bottom': return { x: x + Math.round((w - widgetWidth) / 2), y: y + h - widgetHeight - m, width: widgetWidth, height: widgetHeight }
+    case 'center-left':   return { x: x + m, y: y + Math.round((h - widgetHeight) / 2), width: widgetWidth, height: widgetHeight }
+    case 'center-right':  return { x: x + w - widgetWidth - m, y: y + Math.round((h - widgetHeight) / 2), width: widgetWidth, height: widgetHeight }
+  }
+}
+
+function getCollapsedSize(): { width: number; height: number } {
+  return currentConfig.style === 'icon'
+    ? { width: COLLAPSED_ICON_SIZE, height: COLLAPSED_ICON_SIZE }
+    : { width: COLLAPSED_WIDTH, height: COLLAPSED_HEIGHT }
+}
+
+function getActiveDisplay(): Electron.Display {
+  const cursor = blurCursorPoint ?? screen.getCursorScreenPoint()
+  return screen.getDisplayNearestPoint(cursor)
+}
+
+function applyBounds(animate = false): void {
+  if (!floatingAgentWindow || floatingAgentWindow.isDestroyed()) return
+  const display = getActiveDisplay()
+  const size = isCollapsed
+    ? getCollapsedSize()
+    : { width: EXPANDED_WIDTH, height: Math.round(display.workArea.height * EXPANDED_HEIGHT_RATIO) }
+  const bounds = calcBounds(display.workArea, currentConfig.position, size.width, size.height)
+  floatingAgentWindow.setBounds(bounds, animate)
+}
+
+function readConfig(): void {
+  const db = getDatabase()
+  const row = db.prepare("SELECT value FROM settings WHERE key = 'floatingAgentConfig'").get() as { value: string } | undefined
+  try {
+    currentConfig = row?.value ? { ...DEFAULT_CONFIG, ...JSON.parse(row.value) } : DEFAULT_CONFIG
+  } catch { currentConfig = DEFAULT_CONFIG }
+}
+
+// --- Collapse/Expand ---
+
+function toggleCollapse(): void {
+  if (!floatingAgentWindow || floatingAgentWindow.isDestroyed()) return
+  isCollapsed = !isCollapsed
+  applyBounds(true) // native animation
+  floatingAgentWindow.webContents.send('floating-agent:collapse-changed', isCollapsed)
+}
+
+// --- Window Factory ---
+
+function createFloatingAgentWindow(): BrowserWindow {
+  const win = new BrowserWindow({
+    width: COLLAPSED_WIDTH,
+    height: COLLAPSED_HEIGHT,
+    show: false,
+    alwaysOnTop: true,
+    frame: false,
+    skipTaskbar: true,
+    hasShadow: true,
+    backgroundColor: '#0a0a0a',
+    roundedCorners: true,
+    ...(process.platform === 'darwin' ? { visibleOnAllWorkspaces: true } : {}),
+    webPreferences: {
+      preload: join(__dirname, '../preload/index.js'),
+      sandbox: true,
+      contextIsolation: true,
+      nodeIntegration: false,
+    }
+  })
+
+  const url = is.dev && process.env['ELECTRON_RENDERER_URL']
+    ? `${process.env['ELECTRON_RENDERER_URL']}?floating=agent`
+    : `file://${join(__dirname, '../renderer/index.html')}?floating=agent`
+  win.loadURL(url)
+
+  win.on('focus', () => {
+    if (floatingBlurDebounce) {
+      clearTimeout(floatingBlurDebounce)
+      floatingBlurDebounce = null
+    }
+  })
+
+  win.on('closed', () => {
+    floatingAgentWindow = null
+    currentFloatingSession = null
+  })
+
+  return win
+}
+
+// --- Display Follow ---
+
+function startDisplayFollow(): void {
+  stopDisplayFollow()
+  lastDisplayId = null
+  displayFollowInterval = setInterval(() => {
+    if (!floatingAgentWindow || floatingAgentWindow.isDestroyed() || !floatingDetached) {
+      stopDisplayFollow()
+      return
+    }
+    const cursor = screen.getCursorScreenPoint()
+    const display = screen.getDisplayNearestPoint(cursor)
+    if (display.id === lastDisplayId) return
+    lastDisplayId = display.id
+    applyBounds()
+  }, 500)
+}
+
+function stopDisplayFollow(): void {
+  if (displayFollowInterval) {
+    clearInterval(displayFollowInterval)
+    displayFollowInterval = null
+  }
+  lastDisplayId = null
+}
+
+// --- IPC Handlers ---
+
+function setupFloatingAgentIpc(): void {
+  ipcMain.handle('floating-agent:detach', (_event, sessionId: string, _panelWidth: number) => {
+    if (!mainWindow || floatingDetached) return
+    if (!floatingAgentWindow) floatingAgentWindow = createFloatingAgentWindow()
+
+    const ok = redirectSessionWindow(sessionId, floatingAgentWindow)
+    if (!ok) return
+    floatingDetached = true
+    lastDetachTime = Date.now()
+
+    readConfig()
+    isCollapsed = true
+    applyBounds()
+
+    const db = getDatabase()
+    const row = db.prepare("SELECT value FROM settings WHERE key = 'agentPanelState'").get() as { value: string } | undefined
+    let cwd = ''
+    let mode = 'claude-code'
+    try {
+      const state = row?.value ? JSON.parse(row.value) : {}
+      cwd = state.cwd ?? ''
+      mode = state.mode ?? 'claude-code'
+    } catch { /* use defaults */ }
+    currentFloatingSession = { sessionId, cwd, mode }
+    if (!floatingAgentWindow.isDestroyed()) {
+      floatingAgentWindow.webContents.send('floating-agent:session-changed')
+      floatingAgentWindow.webContents.send('floating-agent:collapse-changed', true)
+    }
+    floatingAgentWindow.show()
+    startDisplayFollow()
+    registerFloatingShortcut()
+  })
+
+  ipcMain.handle('floating-agent:reattach', (_event, sessionId: string) => {
+    if (!floatingDetached) return
+    floatingDetached = false
+    stopDisplayFollow()
+    unregisterFloatingShortcut()
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      redirectSessionWindow(sessionId, mainWindow)
+      const result = getBufferSince(sessionId, -1)
+      if (result) {
+        for (const chunk of result.chunks) {
+          mainWindow.webContents.send('pty:data', sessionId, chunk.data, chunk.seq)
+        }
+      }
+      mainWindow.webContents.send('pty:resize-needed', sessionId)
+    }
+    if (floatingAgentWindow && !floatingAgentWindow.isDestroyed()) {
+      floatingAgentWindow.hide()
+    }
+  })
+
+  ipcMain.handle('floating-agent:get-session', () => currentFloatingSession)
+  ipcMain.handle('floating-agent:get-config', () => currentConfig)
+  ipcMain.handle('floating-agent:toggle-collapse', () => toggleCollapse())
+}
+
+// --- Public API ---
+
+export function attachFloatingAgentBlurHandlers(win: BrowserWindow): void {
+  mainWindow = win
+
+  win.on('blur', () => {
+    blurCursorPoint = screen.getCursorScreenPoint()
+    floatingBlurDebounce = setTimeout(() => {
+      floatingBlurDebounce = null
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.webContents.send('app:window-blur')
+      }
+    }, 80)
+  })
+
+  win.on('focus', () => {
+    if (floatingBlurDebounce) {
+      clearTimeout(floatingBlurDebounce)
+      floatingBlurDebounce = null
+    }
+    if (Date.now() - lastDetachTime < 500) return
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.send('app:window-focus')
+    }
+  })
+
+  win.on('closed', () => {
+    mainWindow = null
+    if (floatingAgentWindow && !floatingAgentWindow.isDestroyed()) {
+      floatingAgentWindow.close()
+    }
+  })
+}
+
+export function setupFloatingAgent(overridesGetter?: () => Record<string, string>): void {
+  if (overridesGetter) getShortcutOverrides = overridesGetter
+  setupFloatingAgentIpc()
+  app.on('will-quit', () => unregisterFloatingShortcut())
+}

--- a/packages/apps/app/src/main/index.ts
+++ b/packages/apps/app/src/main/index.ts
@@ -98,6 +98,7 @@ import { configureTaskRuntimeAdapters, registerTaskHandlers, registerTaskTemplat
 import { registerTagHandlers } from '@slayzone/tags/main'
 import { registerSettingsHandlers, registerThemeHandlers } from '@slayzone/settings/main'
 import { registerPtyHandlers, registerUsageHandlers, killAllPtys, killPtysByTaskId, startIdleChecker, stopIdleChecker, dismissAllNotifications, syncTerminalModes, getPtyPids, onSessionChange, onGlobalStateChange } from '@slayzone/terminal/main'
+import { attachFloatingAgentBlurHandlers, setupFloatingAgent } from './floating-agent'
 import { registerTerminalTabsHandlers } from '@slayzone/task-terminals/main'
 import { registerWorktreeHandlers } from '@slayzone/worktrees/main'
 import { registerDiagnosticsHandlers, registerProcessDiagnostics, recordDiagnosticEvent, stopDiagnostics, setIpcSuccessHook } from '@slayzone/diagnostics/main'
@@ -623,6 +624,9 @@ function createMainWindow(): void {
     return { action: 'deny' }
   })
 
+  // Floating agent panel: blur/focus handlers for detach/reattach
+  attachFloatingAgentBlurHandlers(mainWindow)
+
   mainWindow.on('closed', () => {
     mainWindow = null
   })
@@ -1030,6 +1034,7 @@ app.whenReady().then(async () => {
   registerThemeHandlers(ipcMain, db)
   registerUsageHandlers(ipcMain, db)
   registerPtyHandlers(ipcMain, db)
+  setupFloatingAgent(() => currentOverrides)
 
   // Task automation: auto-move tasks on terminal state change
   onGlobalStateChange((sessionId, newState, oldState) => {

--- a/packages/apps/app/src/preload/index.ts
+++ b/packages/apps/app/src/preload/index.ts
@@ -256,6 +256,33 @@ const api: ElectronAPI = {
     cliStatus: () => ipcRenderer.invoke('app:cli-status'),
     installCli: () => ipcRenderer.invoke('app:install-cli')
   },
+  floatingAgent: {
+    detach: (sessionId: string, panelWidth: number) => ipcRenderer.invoke('floating-agent:detach', sessionId, panelWidth),
+    reattach: (sessionId: string) => ipcRenderer.invoke('floating-agent:reattach', sessionId),
+    getSession: () => ipcRenderer.invoke('floating-agent:get-session'),
+    getConfig: () => ipcRenderer.invoke('floating-agent:get-config'),
+    toggleCollapse: () => ipcRenderer.invoke('floating-agent:toggle-collapse'),
+    onWindowBlur: (callback: () => void) => {
+      const handler = () => callback()
+      ipcRenderer.on('app:window-blur', handler)
+      return () => ipcRenderer.removeListener('app:window-blur', handler)
+    },
+    onWindowFocus: (callback: () => void) => {
+      const handler = () => callback()
+      ipcRenderer.on('app:window-focus', handler)
+      return () => ipcRenderer.removeListener('app:window-focus', handler)
+    },
+    onSessionChanged: (callback: () => void) => {
+      const handler = () => callback()
+      ipcRenderer.on('floating-agent:session-changed', handler)
+      return () => ipcRenderer.removeListener('floating-agent:session-changed', handler)
+    },
+    onCollapseChanged: (callback: (collapsed: boolean) => void) => {
+      const handler = (_: unknown, collapsed: boolean) => callback(collapsed)
+      ipcRenderer.on('floating-agent:collapse-changed', handler)
+      return () => ipcRenderer.removeListener('floating-agent:collapse-changed', handler)
+    },
+  },
   window: {
     close: () => ipcRenderer.invoke('window:close')
   },
@@ -339,6 +366,11 @@ const api: ElectronAPI = {
         callback(sessionId, title)
       ipcRenderer.on('pty:title-change', handler)
       return () => ipcRenderer.removeListener('pty:title-change', handler)
+    },
+    onResizeNeeded: (callback: (sessionId: string) => void) => {
+      const handler = (_event: unknown, sessionId: string) => callback(sessionId)
+      ipcRenderer.on('pty:resize-needed', handler)
+      return () => ipcRenderer.removeListener('pty:resize-needed', handler)
     },
     onStats: (cb) => {
       const handler = (_event: unknown, stats: Record<string, import('@slayzone/types').ProcessStats>) => cb(stats)

--- a/packages/apps/app/src/renderer/src/App.tsx
+++ b/packages/apps/app/src/renderer/src/App.tsx
@@ -400,6 +400,24 @@ function App(): React.JSX.Element {
   const agentPanelShortcut = useShortcutDisplay('agent-panel')
   const agentSessionId = selectedProjectId ? `__agent-panel:${selectedProjectId}` : null
 
+  // Floating agent panel: detach on blur, reattach on focus
+  const floatingDetachedRef = useRef(false)
+  useEffect(() => {
+    const unsubBlur = window.api.floatingAgent.onWindowBlur(() => {
+      if (agentPanelState.isOpen && agentSessionId) {
+        window.api.floatingAgent.detach(agentSessionId, agentPanelState.panelWidth)
+        floatingDetachedRef.current = true
+      }
+    })
+    const unsubFocus = window.api.floatingAgent.onWindowFocus(() => {
+      if (floatingDetachedRef.current && agentSessionId) {
+        window.api.floatingAgent.reattach(agentSessionId)
+        floatingDetachedRef.current = false
+      }
+    })
+    return () => { unsubBlur(); unsubFocus() }
+  }, [agentPanelState.isOpen, agentPanelState.panelWidth, agentSessionId])
+
   // Keyboard shortcuts
   useGuardedHotkeys(getKeys('new-task'), (e) => {
     if (projects.length > 0) { e.preventDefault(); trackShortcut('mod+n'); useDialogStore.getState().openCreateTask() }

--- a/packages/apps/app/src/renderer/src/components/agent-panel/FloatingAgentCollapsed.tsx
+++ b/packages/apps/app/src/renderer/src/components/agent-panel/FloatingAgentCollapsed.tsx
@@ -1,0 +1,42 @@
+import type { TerminalState } from '@slayzone/terminal/shared'
+
+interface Props {
+  state: TerminalState
+  onExpand: () => void
+}
+
+const STATUS_MAP: Record<TerminalState, { color: string; pulse: boolean; text: string }> = {
+  starting:  { color: '#fbbf24', pulse: true,  text: 'starting...' },
+  running:   { color: '#fbbf24', pulse: true,  text: 'working...' },
+  attention: { color: '#4ade80', pulse: false, text: 'waiting for input' },
+  error:     { color: '#ef4444', pulse: false, text: 'error' },
+  dead:      { color: '#666',    pulse: false, text: 'session ended' },
+}
+
+export function FloatingAgentCollapsed({ state, onExpand }: Props) {
+  const status = STATUS_MAP[state] ?? STATUS_MAP.dead
+
+  return (
+    <div className="h-screen w-screen flex flex-col bg-surface-1 cursor-pointer transition-all duration-150 ease-out hover:brightness-125 active:brightness-100 overflow-hidden">
+      {/* Header — draggable */}
+      <div
+        className="flex items-center px-4 pt-2 pb-1.5 gap-2 border-b border-border select-none w-full"
+        style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
+      >
+        <div
+          className={`w-2 h-2 rounded-full shrink-0${status.pulse ? ' animate-pulse' : ''}`}
+          style={{ backgroundColor: status.color }}
+        />
+        <span className="text-[10px] font-semibold text-muted-foreground uppercase tracking-widest leading-none">Agent</span>
+      </div>
+      {/* Body — click to expand */}
+      <button
+        className="flex-1 flex items-center px-4 w-full border-none bg-transparent cursor-pointer"
+        style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+        onClick={onExpand}
+      >
+        <span className="text-[11px] font-mono text-muted-foreground truncate leading-none">{status.text}</span>
+      </button>
+    </div>
+  )
+}

--- a/packages/apps/app/src/renderer/src/components/agent-panel/FloatingAgentCollapsedIcon.tsx
+++ b/packages/apps/app/src/renderer/src/components/agent-panel/FloatingAgentCollapsedIcon.tsx
@@ -1,0 +1,33 @@
+import { TerminalSquare } from 'lucide-react'
+import type { TerminalState } from '@slayzone/terminal/shared'
+
+interface Props {
+  state: TerminalState
+  onExpand: () => void
+}
+
+const DOT_COLORS: Record<TerminalState, string> = {
+  starting:  '#fbbf24',
+  running:   '#fbbf24',
+  attention: '#4ade80',
+  error:     '#ef4444',
+  dead:      '#666',
+}
+
+export function FloatingAgentCollapsedIcon({ state, onExpand }: Props) {
+  const color = DOT_COLORS[state] ?? DOT_COLORS.dead
+  const pulse = state === 'starting' || state === 'running'
+
+  return (
+    <button
+      className="h-screen w-screen flex items-center justify-center rounded-xl border border-border bg-surface-1 cursor-pointer hover:bg-surface-2 transition-colors relative"
+      onClick={onExpand}
+    >
+      <TerminalSquare size={20} className="text-muted-foreground" />
+      <div
+        className={`absolute top-1 right-1 w-2.5 h-2.5 rounded-full border-2 border-surface-1${pulse ? ' animate-pulse' : ''}`}
+        style={{ backgroundColor: color }}
+      />
+    </button>
+  )
+}

--- a/packages/apps/app/src/renderer/src/components/agent-panel/FloatingAgentPanel.tsx
+++ b/packages/apps/app/src/renderer/src/components/agent-panel/FloatingAgentPanel.tsx
@@ -1,0 +1,108 @@
+import { useState, useEffect, useCallback } from 'react'
+import { Terminal } from '@slayzone/terminal/client/Terminal'
+import { usePty } from '@slayzone/terminal/client'
+import type { TerminalMode, TerminalState } from '@slayzone/terminal/shared'
+import { FloatingAgentCollapsed } from './FloatingAgentCollapsed'
+import { FloatingAgentCollapsedIcon } from './FloatingAgentCollapsedIcon'
+
+interface FloatingSession {
+  sessionId: string
+  cwd: string
+  mode: TerminalMode
+}
+
+export function FloatingAgentPanel() {
+  const [session, setSession] = useState<FloatingSession | null>(null)
+  const [collapsed, setCollapsed] = useState(true)
+  const [style, setStyle] = useState<'widget' | 'icon'>('widget')
+  const [terminalState, setTerminalState] = useState<TerminalState>('starting')
+  const [showTerminal, setShowTerminal] = useState(false)
+  const { subscribeState, getState } = usePty()
+
+  useEffect(() => {
+    window.api.floatingAgent.getSession().then((data) => {
+      if (data) setSession({ sessionId: data.sessionId, cwd: data.cwd, mode: data.mode as TerminalMode })
+    })
+    window.api.floatingAgent.getConfig().then((config) => {
+      if (config) setStyle(config.style as 'widget' | 'icon')
+    })
+    const unsub = window.api.floatingAgent.onSessionChanged(() => {
+      window.api.floatingAgent.getSession().then((data) => {
+        if (data) setSession({ sessionId: data.sessionId, cwd: data.cwd, mode: data.mode as TerminalMode })
+      })
+      window.api.floatingAgent.getConfig().then((config) => {
+        if (config) setStyle(config.style as 'widget' | 'icon')
+      })
+    })
+    return unsub
+  }, [])
+
+  useEffect(() => {
+    return window.api.floatingAgent.onCollapseChanged((c) => {
+      setCollapsed(c)
+      if (c) {
+        setShowTerminal(false)
+      } else {
+        setTimeout(() => setShowTerminal(true), 150)
+      }
+    })
+  }, [])
+
+  useEffect(() => {
+    if (!session) return
+    const contextState = getState(session.sessionId)
+    if (contextState !== 'starting') {
+      setTerminalState(contextState)
+    } else {
+      window.api.pty.getState(session.sessionId).then((backendState) => {
+        if (backendState) setTerminalState(backendState)
+      })
+    }
+    return subscribeState(session.sessionId, (newState) => {
+      setTerminalState(newState)
+    })
+  }, [session, getState, subscribeState])
+
+  const handleToggle = useCallback(() => {
+    window.api.floatingAgent.toggleCollapse()
+  }, [])
+
+  if (collapsed) {
+    if (style === 'icon') {
+      return <FloatingAgentCollapsedIcon state={terminalState} onExpand={handleToggle} />
+    }
+    return <FloatingAgentCollapsed state={terminalState} onExpand={handleToggle} />
+  }
+
+  return (
+    <div className="h-screen w-screen flex flex-col bg-surface-1 overflow-hidden rounded-lg border border-border">
+      <div
+        className="shrink-0 h-7 flex items-center justify-between px-3 bg-surface-1 border-b border-border select-none"
+        style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
+      >
+        <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-widest">Agent</span>
+        <button
+          className="w-5 h-5 flex items-center justify-center rounded text-muted-foreground hover:bg-surface-2 hover:text-foreground transition-colors"
+          style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+          onClick={handleToggle}
+          title="Minimize"
+        >
+          &#x2014;
+        </button>
+      </div>
+      <div className={`flex-1 min-h-0 transition-opacity duration-200${showTerminal ? ' opacity-100' : ' opacity-0'}`}>
+        {session && showTerminal ? (
+          <Terminal
+            key={session.sessionId}
+            sessionId={session.sessionId}
+            cwd={session.cwd}
+            mode={session.mode}
+            isActive={true}
+          />
+        ) : (
+          <div className="h-full bg-black" />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/packages/apps/app/src/renderer/src/main.tsx
+++ b/packages/apps/app/src/renderer/src/main.tsx
@@ -7,8 +7,11 @@ import { TelemetryProvider } from '@slayzone/telemetry/client'
 import { UndoProvider } from '@slayzone/ui'
 import { taskDetailCache } from '@slayzone/task/client/taskDetailCache'
 import App from './App'
+import { FloatingAgentPanel } from './components/agent-panel/FloatingAgentPanel'
 import { getDiagnosticsContext } from './lib/diagnosticsClient'
 import { ConvexAuthBootstrap } from './lib/convexAuth'
+
+const isFloatingAgent = new URLSearchParams(window.location.search).get('floating') === 'agent'
 
 window.addEventListener('error', (event) => {
   window.api.diagnostics.recordClientError({
@@ -34,6 +37,18 @@ window.addEventListener('unhandledrejection', (event) => {
   })
 })
 
+// Floating agent panel: minimal renderer — skip tab store, telemetry, convex, etc.
+if (isFloatingAgent) {
+  createRoot(document.getElementById('root')!).render(
+    <PtyProvider>
+      <ThemeProvider>
+        <FloatingAgentPanel />
+      </ThemeProvider>
+    </PtyProvider>
+  )
+}
+
+if (!isFloatingAgent)
 // Wait for tab store to hydrate from SQLite before rendering —
 // prevents race conditions where effects wipe persisted tabs.
 tabStoreReady.then(() => {

--- a/packages/domains/terminal/src/client/Terminal.tsx
+++ b/packages/domains/terminal/src/client/Terminal.tsx
@@ -825,6 +825,15 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
     return subscribeState(sessionId, (newState) => setPtyState(newState))
   }, [sessionId, getState, subscribeState])
 
+  // Re-fit terminal when PTY dimensions need resync (e.g., after floating agent reattach)
+  useEffect(() => {
+    return window.api.pty.onResizeNeeded((sid) => {
+      if (sid !== sessionId || !fitAddonRef.current || !terminalRef.current) return
+      fitAddonRef.current.fit()
+      window.api.pty.resize(sessionId, terminalRef.current.cols, terminalRef.current.rows)
+    })
+  }, [sessionId])
+
   // Safety net: prevent permanent 'starting' state after init completes.
   // If the backend dies or IPC events are lost, this watchdog transitions
   // to 'dead' so the user sees the retry overlay instead of infinite loading.

--- a/packages/domains/terminal/src/main/index.ts
+++ b/packages/domains/terminal/src/main/index.ts
@@ -1,5 +1,5 @@
 export { registerPtyHandlers } from './handlers'
 export { registerUsageHandlers } from './usage'
-export { killAllPtys, killPty, killPtysByTaskId, startIdleChecker, stopIdleChecker, dismissAllNotifications, getPtyPids, onSessionChange, onGlobalStateChange, listPtys, getBuffer, writePty, getState, hasPty, subscribeToPtyData, subscribeToStateChange } from './pty-manager'
+export { killAllPtys, killPty, killPtysByTaskId, startIdleChecker, stopIdleChecker, dismissAllNotifications, getPtyPids, onSessionChange, onGlobalStateChange, listPtys, getBuffer, getBufferSince, writePty, getState, hasPty, subscribeToPtyData, subscribeToStateChange, redirectSessionWindow } from './pty-manager'
 export { resolveUserShell, getShellStartupArgs, whichBinary } from './shell-env'
 export { syncTerminalModes } from './startup-sync'

--- a/packages/domains/terminal/src/main/pty-manager.ts
+++ b/packages/domains/terminal/src/main/pty-manager.ts
@@ -517,7 +517,9 @@ export interface CreatePtyOptions {
 }
 
 export async function createPty(opts: CreatePtyOptions): Promise<{ success: boolean; error?: string }> {
-  const { win, sessionId, cwd, conversationId, existingConversationId, mode, initialPrompt, providerArgs, executionContext, type, initialCommand, resumeCommand, defaultFlags, patternAttention, patternWorking, patternError } = opts
+  const { win: originalWin, sessionId, cwd, conversationId, existingConversationId, mode, initialPrompt, providerArgs, executionContext, type, initialCommand, resumeCommand, defaultFlags, patternAttention, patternWorking, patternError } = opts
+  // Dynamic window lookup: allows redirectSessionWindow() to reroute events at runtime.
+  const getWin = (): BrowserWindow => sessions.get(sessionId)?.win ?? originalWin
   const taskId = taskIdFromSessionId(sessionId)
   const createStartedAt = Date.now()
   let spawnAttempt: { shell: string; shellArgs: string[]; hasPostSpawnCommand: boolean } | null = null
@@ -699,7 +701,7 @@ export async function createPty(opts: CreatePtyOptions): Promise<{ success: bool
     const shellSpawnMs = Date.now() - spawnStartTs
 
     sessions.set(sessionId, {
-      win,
+      win: originalWin,
       pty: ptyProcess,
       sessionId,
       taskId,
@@ -773,12 +775,13 @@ export async function createPty(opts: CreatePtyOptions): Promise<{ success: bool
         sessions.delete(sessionId)
         notifySessionChange()
       }, 100)
-      if (!win.isDestroyed()) {
+      const exitWin = getWin()
+      if (!exitWin.isDestroyed()) {
         try {
-          win.webContents.send('pty:title-change', sessionId, '')
+          exitWin.webContents.send('pty:title-change', sessionId, '')
         } catch { /* Window destroyed */ }
         try {
-          win.webContents.send('pty:exit', sessionId, exitCode)
+          exitWin.webContents.send('pty:exit', sessionId, exitCode)
         } catch {
           // Window destroyed, ignore
         }
@@ -847,6 +850,7 @@ export async function createPty(opts: CreatePtyOptions): Promise<{ success: bool
     const attachPtyHandlers = (target: pty.IPty): void => {
       // Forward data to renderer
       target.onData((data0) => {
+        const win = getWin() // Dynamic lookup for redirectSessionWindow()
         if (firstOutputTs === null) {
           firstOutputTs = Date.now()
           clearStartupTimeout()
@@ -1101,6 +1105,7 @@ export async function createPty(opts: CreatePtyOptions): Promise<{ success: bool
       })
 
       target.onExit(({ exitCode }) => {
+        const win = getWin() // Dynamic lookup for redirectSessionWindow()
         clearStartupTimeout()
         clearEarlyExitWatchdog()
 
@@ -1467,6 +1472,14 @@ export function getPtyPids(): Map<string, number> {
 export function getState(sessionId: string): TerminalState | null {
   const session = sessions.get(sessionId)
   return session?.state ?? null
+}
+
+/** Redirect a PTY session's event output to a different BrowserWindow. */
+export function redirectSessionWindow(sessionId: string, newWin: BrowserWindow): boolean {
+  const session = sessions.get(sessionId)
+  if (!session) return false
+  session.win = newWin
+  return true
 }
 
 export function killAllPtys(): void {

--- a/packages/shared/types/src/api.ts
+++ b/packages/shared/types/src/api.ts
@@ -415,6 +415,17 @@ export interface ElectronAPI {
     cliStatus: () => Promise<{ installed: boolean; path?: string }>
     installCli: () => Promise<{ ok: boolean; path?: string; permissionDenied?: boolean; elevationCancelled?: boolean; error?: string; pathNotInPATH?: boolean }>
   }
+  floatingAgent: {
+    detach: (sessionId: string, panelWidth: number) => Promise<void>
+    reattach: (sessionId: string) => Promise<void>
+    getSession: () => Promise<{ sessionId: string; cwd: string; mode: string } | null>
+    getConfig: () => Promise<{ style: string; position: string }>
+    toggleCollapse: () => Promise<void>
+    onWindowBlur: (callback: () => void) => () => void
+    onWindowFocus: (callback: () => void) => () => void
+    onSessionChanged: (callback: () => void) => () => void
+    onCollapseChanged: (callback: (collapsed: boolean) => void) => () => void
+  }
   window: {
     close: () => Promise<void>
   }
@@ -452,6 +463,7 @@ export interface ElectronAPI {
     onSessionDetected: (callback: (sessionId: string, conversationId: string) => void) => () => void
     onDevServerDetected: (callback: (sessionId: string, url: string) => void) => () => void
     onTitleChange: (callback: (sessionId: string, title: string) => void) => () => void
+    onResizeNeeded: (callback: (sessionId: string) => void) => () => void
     onStats: (cb: (stats: Record<string, ProcessStats>) => void) => () => void
     getState: (sessionId: string) => Promise<TerminalState | null>
     validate: (mode: TerminalMode) => Promise<ValidationResult[]>


### PR DESCRIPTION
Cool project you've been working on, I really like it — especially the recent addition of the persistent agent sidepanel makes it much easier to manage my other terminals/tasks.

I use the agent panel as a kind of ambient orchestrator — it dispatches tasks, monitors other terminals, has context on what I'm working on. The problem is I do a lot of work outside of SlayZone (browser, other terminals, different screens), and switching back to the SlayZone window just to talk to the agent breaks flow.

This PR makes the agent panel auto-detach into a small always-on-top floating widget when SlayZone loses focus. When you click back into SlayZone, it snaps back into the sidebar. Same PTY session throughout, no data loss.

It defaults to a compact collapsed state (~138x52px) showing a status dot and one-line state like "waiting for input." Click it to expand into a full terminal at half display height. Cmd+. toggles between collapsed and expanded. It follows your cursor across displays, is draggable in both states, and works with whatever provider the agent panel is running.

The core trick is swapping `session.win` on the PTY session to route events to whichever BrowserWindow is active, with a dynamic `getWin()` lookup so the `onData`/`onExit` closures read the current window instead of the one captured at creation time.

## Test plan

- [ ] Open agent panel, switch to another app — collapsed mini-terminal appears bottom-right, always on top
- [ ] Click the widget body — expands to full terminal with animation, terminal fades in
- [ ] Click minimize button (em-dash) in expanded header — collapses back
- [ ] Press Cmd+. while floating window visible — toggles collapse/expand
- [ ] Status dot: green when agent is waiting for input, amber pulsing when working
- [ ] Type in expanded floating terminal — input reaches the PTY, agent responds
- [ ] Click back on SlayZone — floating window disappears, agent panel in sidebar shows up-to-date conversation
- [ ] Move cursor to different display — widget repositions within ~500ms
- [ ] Drag the collapsed widget header — window moves freely
- [ ] Drag the expanded panel header — window moves freely

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds auto-detach behavior to the agent side panel: when the main window loses focus, the panel's PTY session is redirected to a small always-on-top floating `BrowserWindow` (collapsed widget or icon), and snapped back on re-focus. The core mechanism is `redirectSessionWindow` in `pty-manager.ts` — it swaps `session.win` at runtime so `onData`/`onExit` closures route IPC events to whichever window is active. Buffer replay on reattach uses existing `seq`-based deduplication in `PtyContext` to apply only the output produced while floating, which is correct. All three P2 findings are edge-case timing issues in the routing layer; the happy path is solid.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for the main use case; three P2 issues in edge-case timing and project-switch paths should be addressed before this ships broadly.

All three findings are P2: the stale win in the session-detection timer, the missing isDestroyed() guard on show(), and the un-reset floatingDetachedRef on project switch. None affect the primary detach/reattach flow, but they can cause orphaned sessions or missed conversation-ID tracking in narrow timing windows.

pty-manager.ts (stale win in setInterval), floating-agent.ts (show() guard), App.tsx (ref not reset on session ID change)
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/apps/app/src/main/floating-agent.ts | New module: implements floating always-on-top BrowserWindow, IPC detach/reattach handlers, display-follow interval, and global shortcut toggle. Minor issue: `show()` called outside the `isDestroyed()` guard. |
| packages/domains/terminal/src/main/pty-manager.ts | Adds `redirectSessionWindow` export and `getWin()` dynamic lookup for onData/onExit. The setInterval inside the first onData invocation still uses the stale `win` closure for `pty:session-detected` notifications after a redirect. |
| packages/apps/app/src/renderer/src/App.tsx | Adds blur/focus effect for auto-detach/reattach. `floatingDetachedRef` is not reset when `agentSessionId` changes, which can orphan the floating session on project switch. |
| packages/apps/app/src/renderer/src/components/agent-panel/FloatingAgentPanel.tsx | Floating renderer root: fetches session/config on mount, subscribes to collapse-changed and state events, renders collapsed widget or expanded terminal. Clean and straightforward. |
| packages/apps/app/src/renderer/src/main.tsx | Minimal renderer bootstrap for the floating window (PtyProvider + ThemeProvider only), correctly skipping telemetry, Convex, and tab-store hydration. |
| packages/domains/terminal/src/client/Terminal.tsx | Adds `onResizeNeeded` handler to re-fit and send updated dimensions after reattach. Clean addition with no issues. |
| packages/apps/app/src/renderer/src/components/agent-panel/FloatingAgentCollapsed.tsx | New collapsed widget component with status dot, drag handle header, and click-to-expand body. Well-structured, no issues. |
| packages/apps/app/src/renderer/src/components/agent-panel/FloatingAgentCollapsedIcon.tsx | Icon-style collapsed variant. Simple and correct. |
| packages/shared/types/src/api.ts | Adds `floatingAgent` typed API surface to ElectronAPI. Types are complete and consistent with the IPC handlers. |
| packages/apps/app/src/preload/index.ts | Exposes `floatingAgent` IPC bridge. All channels are properly sandboxed via contextBridge, listeners return unsub functions. Correct. |
| packages/apps/app/src/main/index.ts | Wires up `attachFloatingAgentBlurHandlers` on the main window and calls `setupFloatingAgent` with the shortcuts override getter. Clean integration. |
| packages/domains/terminal/src/main/index.ts | Exports `redirectSessionWindow` and `getBufferSince` for use by the floating agent module. No issues. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Main as MainWindow
    participant App as App.tsx (renderer)
    participant FMain as floating-agent.ts
    participant PTY as pty-manager.ts
    participant Float as FloatingWindow

    Main->>App: window blur (80ms debounce)
    App->>FMain: IPC floating-agent:detach(sessionId)
    FMain->>PTY: redirectSessionWindow(sessionId, FloatingWindow)
    FMain->>Float: show() + session-changed IPC
    Note over PTY: session.win = FloatingWindow
    PTY-->>Float: pty:data / pty:state-change (live)
    Float-->>App: (hidden, no events)

    Main->>App: window focus
    App->>FMain: IPC floating-agent:reattach(sessionId)
    FMain->>PTY: redirectSessionWindow(sessionId, MainWindow)
    FMain->>Main: replay getBufferSince(sessionId, -1)
    Note over Main: PtyContext deduplicates via lastSeq
    FMain->>Main: pty:resize-needed
    FMain->>Float: hide()
    Note over PTY: session.win = MainWindow
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/domains/terminal/src/main/pty-manager.ts`, line 879-912 ([link](https://github.com/debuglebowski/slayzone/blob/31a184764b36ece82fc4ca0536d8c361c973aa30/packages/domains/terminal/src/main/pty-manager.ts#L879-L912)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Stale `win` closure in session-detection timer**

   The `win` captured from `getWin()` when `firstOutputTs === null` (first data chunk) is closed over inside the `setInterval` callback. After `redirectSessionWindow` redirects the session to the floating window, `getWin()` returns the floating window for new data events — but this timer still holds the original window reference. If the user detaches during the agent startup phase (before detection completes, which can take up to `SESSION_ID_AUTO_DETECT_DELAY_MS × 10` ms), `pty:session-detected` is sent to the main window instead of the floating window, breaking conversation-ID tracking for the floating terminal.

   Or more simply, replace `win` with `getWin()` at the call site inside the interval callback.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/domains/terminal/src/main/pty-manager.ts
   Line: 879-912

   Comment:
   **Stale `win` closure in session-detection timer**

   The `win` captured from `getWin()` when `firstOutputTs === null` (first data chunk) is closed over inside the `setInterval` callback. After `redirectSessionWindow` redirects the session to the floating window, `getWin()` returns the floating window for new data events — but this timer still holds the original window reference. If the user detaches during the agent startup phase (before detection completes, which can take up to `SESSION_ID_AUTO_DETECT_DELAY_MS × 10` ms), `pty:session-detected` is sent to the main window instead of the floating window, breaking conversation-ID tracking for the floating terminal.

   Or more simply, replace `win` with `getWin()` at the call site inside the interval callback.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/domains/terminal/src/main/pty-manager.ts
Line: 879-912

Comment:
**Stale `win` closure in session-detection timer**

The `win` captured from `getWin()` when `firstOutputTs === null` (first data chunk) is closed over inside the `setInterval` callback. After `redirectSessionWindow` redirects the session to the floating window, `getWin()` returns the floating window for new data events — but this timer still holds the original window reference. If the user detaches during the agent startup phase (before detection completes, which can take up to `SESSION_ID_AUTO_DETECT_DELAY_MS × 10` ms), `pty:session-detected` is sent to the main window instead of the floating window, breaking conversation-ID tracking for the floating terminal.

Or more simply, replace `win` with `getWin()` at the call site inside the interval callback.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/apps/app/src/main/floating-agent.ts
Line: 224-229

Comment:
**`show()` called outside the `isDestroyed()` guard**

The `floatingAgentWindow.show()` call falls outside the `if (!floatingAgentWindow.isDestroyed())` guard above it. If the window is destroyed between the guard check and `show()` (e.g., the user closes it via the OS), this throws `Error: Object has been destroyed`.

```suggestion
    if (!floatingAgentWindow.isDestroyed()) {
      floatingAgentWindow.webContents.send('floating-agent:session-changed')
      floatingAgentWindow.webContents.send('floating-agent:collapse-changed', true)
      floatingAgentWindow.show()
    }
    startDisplayFollow()
    registerFloatingShortcut()
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/apps/app/src/renderer/src/App.tsx
Line: 403-419

Comment:
**`floatingDetachedRef` not reset when `agentSessionId` changes**

If the user switches projects while the floating window is active, `agentSessionId` changes, the effect re-registers, but `floatingDetachedRef.current` remains `true`. The new focus listener then calls `reattach(newSessionId)`. Because the main process has `floatingDetached = true` (set by the old detach), reattach proceeds: it redirects the new session ID to the main window (which may not exist), clears `floatingDetached`, and hides the floating window. The old session's `session.win` is left pointing to the now-hidden floating window, orphaning it — future output from that session is routed to a hidden webContents and never shown.

```suggestion
  const floatingDetachedRef = useRef(false)
  useEffect(() => {
    floatingDetachedRef.current = false
    const unsubBlur = window.api.floatingAgent.onWindowBlur(() => {
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: floating agent panel — auto-detach..."](https://github.com/debuglebowski/slayzone/commit/31a184764b36ece82fc4ca0536d8c361c973aa30) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28084638)</sub>

> Greptile also left **2 inline comments** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->