### PR TITLE
fix(cli): make subtask-add parent an option so title default works

### DIFF
--- a/.agents/skills/slay-tasks/SKILL.md
+++ b/.agents/skills/slay-tasks/SKILL.md
@@ -34,8 +34,8 @@ Task commands are the core of the slay CLI. Most commands accept an optional `[i
 
 - `slay tasks subtasks [id] [--json]` — list subtasks of a task.
 
-- `slay tasks subtask-add [parentId] <title> [--description <text>] [--status <status>] [--priority <1-5>] [--external-id <id>] [--external-provider <provider>]`
-  Add a subtask. Parent defaults to `$SLAYZONE_TASK_ID`. The subtask inherits the parent's terminal mode. `--external-id` deduplication works the same as task creation.
+- `slay tasks subtask-add <title> [--parent <id>] [--description <text>] [--status <status>] [--priority <1-5>] [--external-id <id>] [--external-provider <provider>]`
+  Add a subtask. `--parent` defaults to `$SLAYZONE_TASK_ID`. The subtask inherits the parent's terminal mode. `--external-id` deduplication works the same as task creation.
 
 ## Task tags
 

--- a/.claude/skills/slay-tasks/SKILL.md
+++ b/.claude/skills/slay-tasks/SKILL.md
@@ -34,8 +34,8 @@ Task commands are the core of the slay CLI. Most commands accept an optional `[i
 
 - `slay tasks subtasks [id] [--json]` — list subtasks of a task.
 
-- `slay tasks subtask-add [parentId] <title> [--description <text>] [--status <status>] [--priority <1-5>] [--external-id <id>] [--external-provider <provider>]`
-  Add a subtask. Parent defaults to `$SLAYZONE_TASK_ID`. The subtask inherits the parent's terminal mode. `--external-id` deduplication works the same as task creation.
+- `slay tasks subtask-add <title> [--parent <id>] [--description <text>] [--status <status>] [--priority <1-5>] [--external-id <id>] [--external-provider <provider>]`
+  Add a subtask. `--parent` defaults to `$SLAYZONE_TASK_ID`. The subtask inherits the parent's terminal mode. `--external-id` deduplication works the same as task creation.
 
 ## Task tags
 

--- a/packages/apps/app/e2e/git/60-cli.spec.ts
+++ b/packages/apps/app/e2e/git/60-cli.spec.ts
@@ -556,7 +556,26 @@ test.describe('CLI: slay', () => {
 
     test('subtask-add creates a subtask', () => {
       const title = `CLI new subtask ${Date.now()}`
-      const r = runCli('tasks', 'subtask-add', parentTaskId.slice(0, 8), title)
+      const r = runCli('tasks', 'subtask-add', title, '--parent', parentTaskId.slice(0, 8))
+      expect(r.status).toBe(0)
+      expect(r.stdout).toContain('Created subtask:')
+
+      const r2 = runCli('tasks', 'subtasks', parentTaskId.slice(0, 8), '--json')
+      const subtasks = JSON.parse(r2.stdout) as { title: string }[]
+      expect(subtasks.some((t) => t.title === title)).toBe(true)
+    })
+
+    test('subtask-add defaults parent to $SLAYZONE_TASK_ID', () => {
+      const title = `CLI env-default subtask ${Date.now()}`
+      const r = spawnSync('node', [SLAY_JS, 'tasks', 'subtask-add', title], {
+        env: {
+          ...process.env,
+          SLAYZONE_DB_PATH: dbPath,
+          SLAYZONE_MCP_PORT: String(mcpPort),
+          SLAYZONE_TASK_ID: parentTaskId,
+        },
+        encoding: 'utf8',
+      })
       expect(r.status).toBe(0)
       expect(r.stdout).toContain('Created subtask:')
 
@@ -569,11 +588,11 @@ test.describe('CLI: slay', () => {
       const extId = `sub-dedup-${Date.now()}`
       const title = `CLI subtask dedup ${extId}`
 
-      const r1 = runCli('tasks', 'subtask-add', parentTaskId.slice(0, 8), title, '--external-id', extId)
+      const r1 = runCli('tasks', 'subtask-add', title, '--parent', parentTaskId.slice(0, 8), '--external-id', extId)
       expect(r1.status).toBe(0)
       expect(r1.stdout).toContain('Created subtask:')
 
-      const r2 = runCli('tasks', 'subtask-add', parentTaskId.slice(0, 8), 'duplicate', '--external-id', extId)
+      const r2 = runCli('tasks', 'subtask-add', 'duplicate', '--parent', parentTaskId.slice(0, 8), '--external-id', extId)
       expect(r2.status).toBe(0)
       expect(r2.stdout).toContain('Exists:')
       expect(r2.stdout).toContain(title)
@@ -581,7 +600,7 @@ test.describe('CLI: slay', () => {
 
     test('subtask-add populates provider_config with default flags', async ({ mainWindow }) => {
       const title = `CLI subtask flags ${Date.now()}`
-      const r = runCli('tasks', 'subtask-add', parentTaskId.slice(0, 8), title)
+      const r = runCli('tasks', 'subtask-add', title, '--parent', parentTaskId.slice(0, 8))
       expect(r.status).toBe(0)
 
       const subtasks = await mainWindow.evaluate(

--- a/packages/apps/cli/src/commands/tasks.ts
+++ b/packages/apps/cli/src/commands/tasks.ts
@@ -678,17 +678,18 @@ export function tasksCommand(): Command {
       }
     })
 
-  // slay tasks subtask-add [parentId] <title>
+  // slay tasks subtask-add <title>
   cmd
-    .command('subtask-add [parentId] <title>')
-    .description('Add a subtask (parentId defaults to $SLAYZONE_TASK_ID)')
+    .command('subtask-add <title>')
+    .description('Add a subtask (parent defaults to $SLAYZONE_TASK_ID)')
+    .option('--parent <id>', 'Parent task ID (defaults to $SLAYZONE_TASK_ID)')
     .option('--description <text>', 'Subtask description')
     .option('--status <status>', 'Initial status key')
     .option('--priority <n>', 'Priority 1-5', '3')
     .option('--external-id <id>', 'External ID for deduplication (skips if already exists)')
     .option('--external-provider <provider>', 'External provider namespace', 'cli')
-    .action(async (parentId, title, opts) => {
-      parentId = resolveId(parentId)
+    .action(async (title, opts) => {
+      const parentId = resolveId(opts.parent)
       const db = openDb()
 
       const parents = db.query<{ id: string; project_id: string; terminal_mode: string | null }>(

--- a/packages/domains/ai-config/src/shared/skill-marketplace-registry.ts
+++ b/packages/domains/ai-config/src/shared/skill-marketplace-registry.ts
@@ -161,8 +161,8 @@ Task commands are the core of the slay CLI. Most commands accept an optional \`[
 
 - \`slay tasks subtasks [id] [--json]\` — list subtasks of a task.
 
-- \`slay tasks subtask-add [parentId] <title> [--description <text>] [--status <status>] [--priority <1-5>] [--external-id <id>] [--external-provider <provider>]\`
-  Add a subtask. Parent defaults to \`$SLAYZONE_TASK_ID\`. The subtask inherits the parent's terminal mode. \`--external-id\` deduplication works the same as task creation.
+- \`slay tasks subtask-add <title> [--parent <id>] [--description <text>] [--status <status>] [--priority <1-5>] [--external-id <id>] [--external-provider <provider>]\`
+  Add a subtask. \`--parent\` defaults to \`$SLAYZONE_TASK_ID\`. The subtask inherits the parent's terminal mode. \`--external-id\` deduplication works the same as task creation.
 
 ## Task tags
 


### PR DESCRIPTION
## Summary

- `slay tasks subtask-add` fails with `error: missing required argument 'title'` when called with only a title, despite help text advertising that `parentId` defaults to `$SLAYZONE_TASK_ID`.
- Root cause: the command signature was `[parentId] <title>` — an optional positional before a required one. Commander.js cannot disambiguate this; a single positional binds to `parentId`, leaving `title` missing. The documented default was unreachable via the natural one-argument call.
- Fix: switch to `subtask-add <title>` with a `--parent <id>` option (defaulting to `$SLAYZONE_TASK_ID`). This matches the pattern already used by `slay tasks assets create` / `upload`, which face the same "operate on a task with an extra required positional" shape.

Docs and e2e tests updated to the new shape, plus a new e2e test that exercises the `$SLAYZONE_TASK_ID` env-var default path (previously untested, which is why this bug slipped through).

**Breaking**: callers passing parent positionally (`subtask-add <parentId> <title>`) must switch to `subtask-add <title> --parent <parentId>`. Back-compat shim was considered and rejected — the old form was broken for the default case anyway.

## Test plan

- [ ] `pnpm --filter @slayzone/cli build && pnpm --filter @slayzone/cli typecheck`
- [ ] `slay tasks subtask-add 'manual test'` from a task terminal succeeds (env-var default)
- [ ] `slay tasks subtask-add 'manual test' --parent <id>` succeeds (explicit parent)
- [ ] `slay tasks subtask-add --help` shows new signature
- [ ] e2e: `60-cli.spec.ts › subtasks + subtask-add + search` block passes, including new `defaults parent to \$SLAYZONE_TASK_ID` test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes a Commander.js ambiguity bug where `subtask-add [parentId] <title>` caused a single positional argument to bind to `parentId`, leaving `title` missing. The fix replaces the optional positional with a `--parent <id>` option that falls back to `$SLAYZONE_TASK_ID` via the existing `resolveId` helper — matching the pattern used by other task commands. All call sites in tests and docs are updated consistently.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

- Safe to merge — targeted fix with no logic changes beyond the argument shape, all call sites updated, and new test covers the previously-untested env-var default path.
- All findings are P2 or lower. The core fix is correct: `resolveId(opts.parent)` properly handles undefined→env-var fallback and exits cleanly when neither is available. Docs updated in three places consistently. New e2e test exercises the exact scenario that was broken.
- No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/apps/cli/src/commands/tasks.ts | Switches `subtask-add` from `[parentId] <title>` positional pattern to `<title> --parent <id>` option; `resolveId` already handles the `undefined`→env-var fallback correctly. |
| packages/apps/app/e2e/git/60-cli.spec.ts | Updates four call sites to new `--parent` flag and adds a new test that exercises the `$SLAYZONE_TASK_ID` env-var default path using a direct `spawnSync` with a controlled env. |
| .agents/skills/slay-tasks/SKILL.md | Docs updated to reflect new `<title> [--parent <id>]` signature; consistent with CLI and registry changes. |
| .claude/skills/slay-tasks/SKILL.md | Mirror of `.agents/skills/slay-tasks/SKILL.md` update; identical and consistent change. |
| packages/domains/ai-config/src/shared/skill-marketplace-registry.ts | Inline skill doc string updated to match new `subtask-add` signature; no logic changes. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant CLI as slay CLI
    participant resolveId
    participant DB as SQLite DB

    User->>CLI: slay tasks subtask-add "title" [--parent id]
    CLI->>resolveId: resolveId(opts.parent)
    alt --parent provided
        resolveId-->>CLI: opts.parent value
    else --parent omitted
        resolveId->>resolveId: read $SLAYZONE_TASK_ID
        alt env var set
            resolveId-->>CLI: $SLAYZONE_TASK_ID value
        else env var missing
            resolveId-->>CLI: exit(1) — no ID available
        end
    end
    CLI->>DB: SELECT id WHERE id LIKE prefix%
    DB-->>CLI: parent task row
    CLI->>DB: "INSERT INTO tasks (parent_id=parent.id, title=title, ...)"
    DB-->>CLI: ok
    CLI-->>User: "Created subtask: <id> title"
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): make subtask-add parent an opt..."](https://github.com/debuglebowski/slayzone/commit/625c7952a9924d8090a5ee45ef3514f1bffcd823) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28350963)</sub>

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->