### PR TITLE
fix(file-editor): show rename input for directory entries

### DIFF
--- a/packages/domains/file-editor/src/client/EditorFileTree.tsx
+++ b/packages/domains/file-editor/src/client/EditorFileTree.tsx
@@ -142,6 +142,7 @@ export const EditorFileTree = forwardRef<EditorFileTreeHandle, EditorFileTreePro
     if (willCreateRef.current) { e.preventDefault(); willCreateRef.current = false }
   }, [])
   const renameInputRef = useRef<HTMLInputElement>(null)
+  const cancelRenameRef = useRef(false)
 
   // --- Drag and drop state ---
   const dragPathRef = useRef<string | null>(null)
@@ -840,10 +841,10 @@ export const EditorFileTree = forwardRef<EditorFileTreeHandle, EditorFileTreePro
                 value={renameValue}
                 onChange={(e) => setRenameValue(e.target.value)}
                 onKeyDown={(e) => {
-                  if (e.key === 'Enter') handleRename(entry.path, renameValue)
-                  if (e.key === 'Escape') setRenaming(null)
+                  if (e.key === 'Enter') { cancelRenameRef.current = false; handleRename(entry.path, renameValue) }
+                  if (e.key === 'Escape') { cancelRenameRef.current = true; setRenaming(null) }
                 }}
-                onBlur={() => handleRename(entry.path, renameValue)}
+                onBlur={() => { if (!cancelRenameRef.current) handleRename(entry.path, renameValue); cancelRenameRef.current = false }}
                 className="h-6 text-xs font-mono py-0 px-1"
               />
             </div>
@@ -916,10 +917,10 @@ export const EditorFileTree = forwardRef<EditorFileTreeHandle, EditorFileTreePro
             value={renameValue}
             onChange={(e) => setRenameValue(e.target.value)}
             onKeyDown={(e) => {
-              if (e.key === 'Enter') handleRename(entry.path, renameValue)
-              if (e.key === 'Escape') setRenaming(null)
+              if (e.key === 'Enter') { cancelRenameRef.current = false; handleRename(entry.path, renameValue) }
+              if (e.key === 'Escape') { cancelRenameRef.current = true; setRenaming(null) }
             }}
-            onBlur={() => handleRename(entry.path, renameValue)}
+            onBlur={() => { if (!cancelRenameRef.current) handleRename(entry.path, renameValue); cancelRenameRef.current = false }}
             className="h-6 text-xs font-mono py-0 px-1"
           />
         </div>

--- a/packages/domains/file-editor/src/client/EditorFileTree.tsx
+++ b/packages/domains/file-editor/src/client/EditorFileTree.tsx
@@ -832,37 +832,54 @@ export const EditorFileTree = forwardRef<EditorFileTreeHandle, EditorFileTreePro
           onDrop={(e) => handleFolderDrop(e, entry.path)}
           className={cn(isDropHover && 'bg-primary/10 ring-1 ring-primary/30 rounded')}
         >
-          <ContextMenu>
-            <ContextMenuTrigger asChild>
-              <button
-                draggable
-                onDragStart={(e) => handleDragStart(e, entry)}
-                onDragEnd={handleDragEnd}
-                data-path={entry.path}
-                className={cn(
-                  'group/folder flex w-full select-none items-center gap-1.5 rounded px-1 py-1 text-xs hover:bg-muted/50',
-                  isSelected && 'bg-primary/15',
-                  isFocused && 'ring-1 ring-primary/40',
-                  isCut && 'opacity-40',
-                  entry.ignored && 'opacity-40'
-                )}
-                style={{ paddingLeft: pad }}
-                onClick={(e) => handleEntryClick(e, entry, chainPaths)}
-              >
-                {expanded
-                  ? <FolderOpen className="size-4 shrink-0 text-amber-400" />
-                  : <Folder className="size-4 shrink-0 text-amber-500/80" />}
-                <span className={cn("truncate font-mono", gitStatusColor(dirGitStatus.get(entry.path)), entry.ignored && 'italic')}>{label}</span>
-                <GitStatusBadge status={dirGitStatus.get(entry.path)} />
-                {entry.isSymlink && (
-                  <span title="Symbolic link"><ArrowUpRight className="size-3 shrink-0 text-muted-foreground/60" /></span>
-                )}
-              </button>
-            </ContextMenuTrigger>
-            <ContextMenuContent onCloseAutoFocus={preventAutoFocus}>
-              {renderContextMenuItems(entry, true)}
-            </ContextMenuContent>
-          </ContextMenu>
+          {renaming === entry.path ? (
+            <div style={{ paddingLeft: pad }} className="flex items-center gap-1.5 py-0.5">
+              <Folder className="size-4 shrink-0 text-amber-500/80" />
+              <Input
+                ref={renameInputRef}
+                value={renameValue}
+                onChange={(e) => setRenameValue(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') handleRename(entry.path, renameValue)
+                  if (e.key === 'Escape') setRenaming(null)
+                }}
+                onBlur={() => handleRename(entry.path, renameValue)}
+                className="h-6 text-xs font-mono py-0 px-1"
+              />
+            </div>
+          ) : (
+            <ContextMenu>
+              <ContextMenuTrigger asChild>
+                <button
+                  draggable
+                  onDragStart={(e) => handleDragStart(e, entry)}
+                  onDragEnd={handleDragEnd}
+                  data-path={entry.path}
+                  className={cn(
+                    'group/folder flex w-full select-none items-center gap-1.5 rounded px-1 py-1 text-xs hover:bg-muted/50',
+                    isSelected && 'bg-primary/15',
+                    isFocused && 'ring-1 ring-primary/40',
+                    isCut && 'opacity-40',
+                    entry.ignored && 'opacity-40'
+                  )}
+                  style={{ paddingLeft: pad }}
+                  onClick={(e) => handleEntryClick(e, entry, chainPaths)}
+                >
+                  {expanded
+                    ? <FolderOpen className="size-4 shrink-0 text-amber-400" />
+                    : <Folder className="size-4 shrink-0 text-amber-500/80" />}
+                  <span className={cn("truncate font-mono", gitStatusColor(dirGitStatus.get(entry.path)), entry.ignored && 'italic')}>{label}</span>
+                  <GitStatusBadge status={dirGitStatus.get(entry.path)} />
+                  {entry.isSymlink && (
+                    <span title="Symbolic link"><ArrowUpRight className="size-3 shrink-0 text-muted-foreground/60" /></span>
+                  )}
+                </button>
+              </ContextMenuTrigger>
+              <ContextMenuContent onCloseAutoFocus={preventAutoFocus}>
+                {renderContextMenuItems(entry, true)}
+              </ContextMenuContent>
+            </ContextMenu>
+          )}
 
           {expanded && compactChildren(entry.path, dirContents).map((c) =>
             renderEntry(c.entry, depth + 1, c.displayName, c.chainPaths)


### PR DESCRIPTION
## Summary

- Right-clicking a folder and selecting **Rename** had no visible effect
- Files renamed correctly; folders did not

## Root Cause

In `EditorFileTree.tsx`, `renderEntry()` returned early for `entry.type === 'directory'` before reaching the `renaming === entry.path` check that renders the inline `<Input>`. The `startRename` handler correctly set state for both files and folders, but the input was never rendered for directories.

## Fix

Wrapped the folder `<ContextMenu>` block in a conditional: when `renaming === entry.path`, render the rename `<Input>` instead of the folder button. Mirrors the existing pattern used for the inline create input.

The `handleRename` callback already supported directories — no changes needed there.

## Testing

1. Open the **Editor** tab
2. Right-click a folder → **Rename**
3. Inline input appears pre-filled with the folder name
4. Edit + <kbd>Enter</kbd> → folder renamed on disk
5. <kbd>Escape</kbd> → rename cancelled
6. File rename still works (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes directory rename in `EditorFileTree` by wrapping the folder `<ContextMenu>` block in a conditional that renders an inline `<Input>` when `renaming === entry.path`, mirroring the existing file-rename pattern. It also introduces `cancelRenameRef` to prevent the Escape→blur double-invoke bug for both directory and file rename paths.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — targeted fix with no regressions; mirrors the existing proven file-rename pattern.

Only one file changed, the logic is a clean conditional wrap that mirrors the pre-existing file rename path, and the cancelRenameRef addition correctly fixes the Escape→onBlur double-invoke for both entry types. No new failure modes introduced.

No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/domains/file-editor/src/client/EditorFileTree.tsx | Adds conditional directory rename input matching file rename pattern; adds cancelRenameRef to fix Escape→onBlur double-rename for both entry types. Logic is clean and correctly shares the single renameInputRef/useEffect focus mechanism since only one rename can be active at a time. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["renderEntry(entry)"] --> B{entry.type === 'directory'?}
    B -- No --> C{renaming === entry.path?}
    B -- Yes --> D{renaming === entry.path?}
    D -- Yes --> E["Render Input with cancelRenameRef logic"]
    D -- No --> F["Render ContextMenu + folder button"]
    C -- Yes --> G["Render Input with cancelRenameRef logic"]
    C -- No --> H["Render ContextMenu + file button"]
    E --> I["onKeyDown Enter → handleRename"]
    E --> J["onKeyDown Escape → cancelRenameRef=true, setRenaming(null)"]
    E --> K["onBlur → if !cancelRenameRef: handleRename"]
    G --> I
    G --> J
    G --> K
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/domains/file-editor/src/client/EditorFileTree.tsx`, line 311-318 ([link](https://github.com/debuglebowski/slayzone/blob/ce6f05c23b78f8304674602576b0606db6204e84/packages/domains/file-editor/src/client/EditorFileTree.tsx#L311-L318)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Expanded state lost after directory rename**

   After `handleRename` succeeds, it only calls `loadDir(parentDir)` to refresh the tree listing but never updates `expandedFolders`. Any directory that was open before the rename — including the renamed folder itself and its expanded descendants — will appear collapsed after the operation. The drag-and-drop move handler (around line 591) already implements the correct path-remapping logic for `expandedFolders`; the same remapping is needed here.

   ```ts
   await window.api.fs.rename(projectPath, oldPath, newPath)
   track('file_renamed')
   onFileRenamed?.(oldPath, newPath)
   // Remap expanded-folder paths so the renamed dir stays expanded
   const oldPrefix = oldPath + '/'
   setExpandedFolders((prev) => {
     let changed = false
     const next = new Set<string>()
     for (const p of prev) {
       if (p === oldPath) { next.add(newPath); changed = true }
       else if (p.startsWith(oldPrefix)) { next.add(newPath + p.slice(oldPath.length)); changed = true }
       else next.add(p)
     }
     return changed ? next : prev
   })
   await loadDir(parentDir)
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/domains/file-editor/src/client/EditorFileTree.tsx
   Line: 311-318

   Comment:
   **Expanded state lost after directory rename**

   After `handleRename` succeeds, it only calls `loadDir(parentDir)` to refresh the tree listing but never updates `expandedFolders`. Any directory that was open before the rename — including the renamed folder itself and its expanded descendants — will appear collapsed after the operation. The drag-and-drop move handler (around line 591) already implements the correct path-remapping logic for `expandedFolders`; the same remapping is needed here.

   ```ts
   await window.api.fs.rename(projectPath, oldPath, newPath)
   track('file_renamed')
   onFileRenamed?.(oldPath, newPath)
   // Remap expanded-folder paths so the renamed dir stays expanded
   const oldPrefix = oldPath + '/'
   setExpandedFolders((prev) => {
     let changed = false
     const next = new Set<string>()
     for (const p of prev) {
       if (p === oldPath) { next.add(newPath); changed = true }
       else if (p.startsWith(oldPrefix)) { next.add(newPath + p.slice(oldPath.length)); changed = true }
       else next.add(p)
     }
     return changed ? next : prev
   })
   await loadDir(parentDir)
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(file-editor): prevent Escape from tr..."](https://github.com/debuglebowski/slayzone/commit/bece1b700b8b5dabbf0a92da4b05fefb6b0d8f8a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28396739)</sub>

<!-- /greptile_comment -->