### PR TITLE
feat(worktrees): color-code worktree list and never color-code main worktree

### DIFF
--- a/packages/apps/app/src/renderer/src/hooks/useTabColors.ts
+++ b/packages/apps/app/src/renderer/src/hooks/useTabColors.ts
@@ -2,8 +2,7 @@ import { useMemo } from 'react'
 import type { Task } from '@slayzone/task/shared'
 import type { Project } from '@slayzone/projects/shared'
 import type { Tab } from '@slayzone/settings'
-
-const WORKTREE_COLORS = ['#6366f1', '#f59e0b', '#10b981', '#ef4444', '#8b5cf6', '#ec4899', '#06b6d4', '#84cc16']
+import { WORKTREE_COLORS, hashStr } from '@slayzone/ui'
 
 export function useTabColors(
   tabs: Tab[],
@@ -26,26 +25,18 @@ export function useTabColors(
 
   const taskWorktreeColors = useMemo(() => {
     const map = new Map<string, string>()
-    const byProject = new Map<string, { taskId: string; effectivePath: string }[]>()
+    const byProject = new Map<string, { taskId: string; worktreePath: string }[]>()
     for (const tab of tabs) {
       if (tab.type !== 'task') continue
       const task = tasks.find((t) => t.id === tab.taskId)
       if (!task?.project_id) continue
-      const project = projects.find((p) => p.id === task.project_id)
-      const effectivePath = task.worktree_path || project?.path
-      if (!effectivePath) continue
+      if (!task.worktree_path) continue
       const group = byProject.get(task.project_id) ?? []
-      group.push({ taskId: tab.taskId, effectivePath })
+      group.push({ taskId: tab.taskId, worktreePath: task.worktree_path })
       byProject.set(task.project_id, group)
     }
-    const hashStr = (s: string): number => {
-      let h = 0
-      for (let i = 0; i < s.length; i++) h = ((h << 5) - h + s.charCodeAt(i)) | 0
-      return Math.abs(h)
-    }
     for (const entries of byProject.values()) {
-      const distinctPaths = [...new Set(entries.map((e) => e.effectivePath))]
-      if (distinctPaths.length < 2) continue
+      const distinctPaths = [...new Set(entries.map((e) => e.worktreePath))]
       const pathToColor = new Map<string, string>()
       const usedIndices = new Set<number>()
       for (const path of distinctPaths) {
@@ -55,11 +46,11 @@ export function useTabColors(
         pathToColor.set(path, WORKTREE_COLORS[idx])
       }
       for (const entry of entries) {
-        map.set(entry.taskId, pathToColor.get(entry.effectivePath)!)
+        map.set(entry.taskId, pathToColor.get(entry.worktreePath)!)
       }
     }
     return map
-  }, [tabs, tasks, projects])
+  }, [tabs, tasks])
 
   const tabCycleOrder = useMemo(() => {
     const homeIndex = tabs.findIndex((tab) => tab.type === 'home')

--- a/packages/apps/app/src/renderer/src/hooks/useTabColors.ts
+++ b/packages/apps/app/src/renderer/src/hooks/useTabColors.ts
@@ -36,7 +36,7 @@ export function useTabColors(
       byProject.set(task.project_id, group)
     }
     for (const entries of byProject.values()) {
-      const distinctPaths = [...new Set(entries.map((e) => e.worktreePath))]
+      const distinctPaths = [...new Set(entries.map((e) => e.worktreePath))].sort()
       const pathToColor = new Map<string, string>()
       const usedIndices = new Set<number>()
       for (const path of distinctPaths) {

--- a/packages/domains/worktrees/src/client/WorktreesTab.tsx
+++ b/packages/domains/worktrees/src/client/WorktreesTab.tsx
@@ -33,7 +33,9 @@ import {
   TooltipContent,
   TooltipTrigger,
   Input,
-  PriorityIcon
+  PriorityIcon,
+  WORKTREE_COLORS,
+  hashStr
 } from '@slayzone/ui'
 import { type FilterState, groupTasksBy, getViewConfig, type Column } from '@slayzone/tasks'
 import { resolveColumns } from '@slayzone/projects/shared'
@@ -41,7 +43,6 @@ import type { Task } from '@slayzone/task/shared'
 import type { DetectedWorktree } from '../shared/types'
 import { CreateWorktreeDialog } from './CreateWorktreeDialog'
 import { useGitPanelContext } from './UnifiedGitPanel'
-
 
 interface WorktreesTabProps {
   visible: boolean
@@ -193,6 +194,20 @@ export const WorktreesTab = forwardRef<WorktreesTabHandle, WorktreesTabProps>(fu
     return rootNodes
   }, [worktrees, tasks])
 
+  const worktreeColorMap = useMemo(() => {
+    const map = new Map<string, string>()
+    const nonMain = worktrees.filter(wt => !wt.isMain)
+    if (nonMain.length === 0) return map
+    const usedIndices = new Set<number>()
+    for (const wt of nonMain) {
+      let idx = hashStr(wt.path) % WORKTREE_COLORS.length
+      while (usedIndices.has(idx) && usedIndices.size < WORKTREE_COLORS.length) idx = (idx + 1) % WORKTREE_COLORS.length
+      usedIndices.add(idx)
+      map.set(wt.path, WORKTREE_COLORS[idx])
+    }
+    return map
+  }, [worktrees])
+
   const handleRemoveWorktree = async (path: string) => {
     if (!projectPath) return
     try {
@@ -244,6 +259,7 @@ export const WorktreesTab = forwardRef<WorktreesTabHandle, WorktreesTabProps>(fu
               <WorktreeCard
                 key={node.path}
                 node={{ ...node, isDirty: dirtyStatuses[node.path] ?? false }}
+                worktreeColor={worktreeColorMap.get(node.path)}
                 isExpanded={expandedPaths.has(node.path)}
                 onToggleExpand={() => toggleExpand(node.path)}
                 onRemove={() => setDeleteConfirmOpen(node.path)}
@@ -476,12 +492,14 @@ function renderTree(nodes: WorktreeNode[], expandedPaths: Set<string>, renderNod
 
 function WorktreeCard({
   node,
+  worktreeColor,
   isExpanded,
   onToggleExpand,
   onRemove,
   onAssign
 }: {
   node: WorktreeNode
+  worktreeColor?: string
   isExpanded: boolean
   onToggleExpand: () => void
   onRemove: () => void
@@ -523,16 +541,22 @@ function WorktreeCard({
         </div>
       )}
 
-      <div 
+      <div
         className={cn(
           "mb-1 rounded-lg border transition-all",
-          isActive 
-            ? "border-primary/50 bg-primary/10 shadow-md ring-1 ring-primary/20" 
-            : node.isMain 
-              ? "border-primary/20 bg-primary/5 shadow-sm" 
+          isActive
+            ? "border-primary/50 bg-primary/10 shadow-md ring-1 ring-primary/20"
+            : node.isMain
+              ? "border-primary/20 bg-primary/5 shadow-sm"
               : "border-border bg-surface-1 hover:border-border/80 hover:shadow-sm"
         )}
-        style={{ marginLeft: node.depth * 20 }}
+        style={{
+          marginLeft: node.depth * 20,
+          ...(worktreeColor && {
+            borderLeftWidth: 3,
+            borderLeftColor: worktreeColor,
+          })
+        }}
       >
         <div className="p-3 space-y-2">
           <div className="flex items-center gap-2">

--- a/packages/domains/worktrees/src/client/WorktreesTab.tsx
+++ b/packages/domains/worktrees/src/client/WorktreesTab.tsx
@@ -196,14 +196,14 @@ export const WorktreesTab = forwardRef<WorktreesTabHandle, WorktreesTabProps>(fu
 
   const worktreeColorMap = useMemo(() => {
     const map = new Map<string, string>()
-    const nonMain = worktrees.filter(wt => !wt.isMain)
-    if (nonMain.length === 0) return map
+    const paths = worktrees.filter(wt => !wt.isMain).map(wt => wt.path).sort()
+    if (paths.length === 0) return map
     const usedIndices = new Set<number>()
-    for (const wt of nonMain) {
-      let idx = hashStr(wt.path) % WORKTREE_COLORS.length
+    for (const path of paths) {
+      let idx = hashStr(path) % WORKTREE_COLORS.length
       while (usedIndices.has(idx) && usedIndices.size < WORKTREE_COLORS.length) idx = (idx + 1) % WORKTREE_COLORS.length
       usedIndices.add(idx)
-      map.set(wt.path, WORKTREE_COLORS[idx])
+      map.set(path, WORKTREE_COLORS[idx])
     }
     return map
   }, [worktrees])

--- a/packages/shared/ui/src/index.ts
+++ b/packages/shared/ui/src/index.ts
@@ -20,6 +20,7 @@ export { useShortcutStore } from './useShortcutStore'
 export { useShortcutDisplay } from './useShortcutDisplay'
 export { useShortcutAction } from './useShortcutAction'
 export { projectColorBg, type ProjectColorVariant } from './project-color'
+export { WORKTREE_COLORS, hashStr } from './worktree-color'
 export { useAppearance, AppearanceContext, appearanceDefaults, type AppearanceSettings, type BrowserDeviceDefaults } from './AppearanceContext'
 export { getTerminalStateStyle, type TerminalStateStyle } from './terminal-state'
 export {

--- a/packages/shared/ui/src/worktree-color.ts
+++ b/packages/shared/ui/src/worktree-color.ts
@@ -1,0 +1,7 @@
+export const WORKTREE_COLORS = ['#6366f1', '#f59e0b', '#10b981', '#ef4444', '#8b5cf6', '#ec4899', '#06b6d4', '#84cc16']
+
+export function hashStr(path: string): number {
+  let h = 0
+  for (let i = 0; i < path.length; i++) h = ((h << 5) - h + path.charCodeAt(i)) | 0
+  return Math.abs(h)
+}


### PR DESCRIPTION
## Summary
- Apply tab-bar worktree color coding to the Worktrees panel — each non-main worktree row gets a tinted left border matching its tab color.
- Main repo is never tinted; only additional worktrees get colors so they're visually distinguishable.
- Palette + hash extracted to `@slayzone/ui/worktree-color` so tab bar and worktree list share a single source of truth.

## Test plan
- [x] Open a project with 2+ worktrees; confirm each non-main row has a colored left border in the Worktrees tab
- [x] Confirm the Main Repository row has no tint
- [x] Confirm tab colors still match their corresponding worktree rows
- [x] Typecheck passes

## Before/After

### Before
<img width="1757" height="649" alt="image" src="https://github.com/user-attachments/assets/cee2bd0c-9c3e-4e43-b5c4-7229a3e1951b" />

### After
<img width="1761" height="541" alt="image" src="https://github.com/user-attachments/assets/7d68a43a-064c-4395-a97d-39c6bb3fb557" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Extracts the worktree color palette and `hashStr` into a shared `@slayzone/ui/worktree-color` module, then applies tinted left-border color coding to non-main rows in the Worktrees panel while leaving the Main Repository row untinted. The probe-order issue flagged in the previous review is fixed by sorting paths lexicographically in both `useTabColors` and `worktreeColorMap` before iterating.

One residual concern: `WorktreesTab` seeds its color map from all git-detected non-main worktrees, while `useTabColors` seeds from only the paths of tasks currently open in tabs. If those sets differ when a hash collision exists, the same worktree can receive a different color in the two contexts — see inline comment for a concrete example.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for typical usage; one residual edge-case where colors can diverge between panel and tab bar under hash collision + partial tab coverage.

The probe-order fix (sorting) directly addresses the prior review concern. The remaining input-set divergence is an edge case requiring both a hash collision and some non-main worktrees having no open tab tasks simultaneously — real but unlikely in normal usage. No regressions to main-worktree behavior or existing functionality are introduced.

packages/apps/app/src/renderer/src/hooks/useTabColors.ts and packages/domains/worktrees/src/client/WorktreesTab.tsx — both use different input sets for color assignment which can diverge under hash collision.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/shared/ui/src/worktree-color.ts | New shared module extracting WORKTREE_COLORS palette and hashStr — clean single source of truth, no issues. |
| packages/shared/ui/src/index.ts | Adds export for WORKTREE_COLORS and hashStr from new worktree-color module — straightforward barrel export change. |
| packages/apps/app/src/renderer/src/hooks/useTabColors.ts | Now only colors tasks with an explicit worktree_path, sorts paths for deterministic probe order, and removes the length < 2 guard; remaining concern is that its input set (open-tab paths) can diverge from WorktreesTab's input set (all git-detected paths), causing color mismatches under hash collision. |
| packages/domains/worktrees/src/client/WorktreesTab.tsx | Adds worktreeColorMap built from all git-detected non-main paths (sorted), passes color to WorktreeCard for a tinted left border; same input-set divergence concern as useTabColors applies when some worktrees have no open tab tasks and a hash collision occurs. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[worktree-color.ts\nWORKTREE_COLORS + hashStr] --> B[useTabColors.ts]
    A --> C[WorktreesTab.tsx]

    B --> B1[Filter tasks with worktree_path]
    B1 --> B2[Group by project_id]
    B2 --> B3[distinctPaths = Set of paths .sort]
    B3 --> B4[Hash-probe → pathToColor map]
    B4 --> B5[taskWorktreeColors\nMap taskId → color]

    C --> C1[worktrees.filter not isMain .sort]
    C1 --> C2[Hash-probe → worktreeColorMap\nMap path → color]
    C2 --> C3[WorktreeCard\nborderLeftColor = worktreeColor]

    B5 --> D[Tab bar tint]
    C3 --> E[Worktrees panel tint]

    style D fill:#6366f1,color:#fff
    style E fill:#6366f1,color:#fff
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/domains/worktrees/src/client/WorktreesTab.tsx
Line: 197-208

Comment:
**Input-set divergence can still produce mismatched colors under hash collision**

`worktreeColorMap` here is seeded from all git-detected non-main worktrees; `taskWorktreeColors` in `useTabColors` is seeded only from paths of tasks that are currently open in tabs. When those sets differ and two paths share the same `hashStr(p) % 8` bucket, the probe can resolve differently in each context and a worktree ends up with a different color in the panel vs its tab.

Concrete example — two worktrees A and B both hash to slot 3, sorted order A < B:
- WorktreesTab (sees A + B): A→3, B→4
- useTabColors (only B is in a tab): B→3 ← mismatch

The sorting fix from the previous review eliminates the *iteration-order* variant of this problem, but doesn't protect against the *input-set* variant. To make both contexts fully consistent, `useTabColors` could accept the full detected-worktree paths for each project (or use the same git-detected list), so both map over an identical sorted input.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(worktrees): sort paths before color ..."](https://github.com/debuglebowski/slayzone/commit/0877826b3dc2da097d51dd873492d8f287fae73b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28742570)</sub>

<!-- /greptile_comment -->