### PR TITLE
feat(worktrees): recursive file selection in copy-files dialog

### DIFF
--- a/packages/domains/worktrees/src/client/CopyFilesDialog.tsx
+++ b/packages/domains/worktrees/src/client/CopyFilesDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
 import { Loader2, Folder, File, ChevronRight } from 'lucide-react'
 import {
   Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription,
@@ -20,41 +20,7 @@ interface CopyFilesDialogProps {
   onConfirm: (choice: CopyChoice) => void
 }
 
-function flattenTree(nodes: IgnoredFileNode[]): string[] {
-  const result: string[] = []
-  for (const node of nodes) {
-    result.push(node.name)
-  }
-  return result
-}
-
-function filterTreeByGlobs(nodes: IgnoredFileNode[], globs: string[]): Set<string> {
-  if (globs.length === 0) return new Set(flattenTree(nodes))
-
-  // Split globs into: single-segment (match file/dir name) and multi-segment (match dir by first segment)
-  const fileMatchers: RegExp[] = []
-  const dirPrefixes: string[] = []
-  for (const glob of globs) {
-    const firstSlash = glob.indexOf('/')
-    if (firstSlash === -1) {
-      // Single-segment glob like "*.md" or ".env*"
-      fileMatchers.push(globToRegex(glob))
-    } else {
-      // Multi-segment glob like "docs/**" — extract first segment
-      dirPrefixes.push(glob.slice(0, firstSlash))
-    }
-  }
-
-  const matched = new Set<string>()
-  for (const node of nodes) {
-    if (fileMatchers.some(re => re.test(node.name))) {
-      matched.add(node.name)
-    } else if (node.isDirectory && dirPrefixes.includes(node.name)) {
-      matched.add(node.name)
-    }
-  }
-  return matched
-}
+type NodeState = 'checked' | 'indeterminate' | 'unchecked'
 
 function globToRegex(pattern: string): RegExp {
   const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&')
@@ -65,6 +31,41 @@ function globToRegex(pattern: string): RegExp {
   return new RegExp(`^${escaped}$`)
 }
 
+function filterTreeByGlobs(nodes: IgnoredFileNode[], globs: string[]): Set<string> {
+  if (globs.length === 0) return new Set(nodes.map(n => n.path))
+
+  // Single-segment globs (e.g. ".env*") match a file's basename at any depth.
+  // Multi-segment globs (e.g. "docs/**") match the top-level dir by first segment.
+  const basenameMatchers: RegExp[] = []
+  const dirPrefixes: string[] = []
+  for (const glob of globs) {
+    const firstSlash = glob.indexOf('/')
+    if (firstSlash === -1) {
+      basenameMatchers.push(globToRegex(glob))
+    } else {
+      dirPrefixes.push(glob.slice(0, firstSlash))
+    }
+  }
+
+  const matched = new Set<string>()
+
+  for (const node of nodes) {
+    if (node.isDirectory && dirPrefixes.includes(node.name)) {
+      matched.add(node.path)
+    }
+  }
+
+  const walk = (node: IgnoredFileNode) => {
+    if (!node.isDirectory && basenameMatchers.some(re => re.test(node.name))) {
+      matched.add(node.path)
+    }
+    for (const child of node.children) walk(child)
+  }
+  for (const node of nodes) walk(node)
+
+  return matched
+}
+
 function formatBytes(bytes: number): string {
   if (bytes === 0) return '0 B'
   const units = ['B', 'KB', 'MB', 'GB']
@@ -73,37 +74,135 @@ function formatBytes(bytes: number): string {
   return `${val < 10 ? val.toFixed(1) : Math.round(val)} ${units[i]}`
 }
 
-function TreeRow({ node, depth, expanded, onToggleExpand }: {
+/**
+ * Compute per-node checkbox state + the total number of files covered.
+ * Selection model: `selected` is a set of "selection roots" — either a file path
+ * or a dir path meaning the whole subtree is copied. Invariant: no ancestor and
+ * descendant appear together.
+ */
+function computeStates(tree: IgnoredFileNode[], selected: Set<string>): {
+  states: Map<string, NodeState>
+  selectedCounts: Map<string, number>
+  selectedFileCount: number
+} {
+  const states = new Map<string, NodeState>()
+  const selectedCounts = new Map<string, number>()
+  let selectedFileCount = 0
+
+  const walk = (node: IgnoredFileNode, ancestorSelected: boolean): { state: NodeState; count: number } => {
+    const inherited = ancestorSelected || selected.has(node.path)
+    if (!node.isDirectory) {
+      const st: NodeState = inherited ? 'checked' : 'unchecked'
+      states.set(node.path, st)
+      const count = inherited ? 1 : 0
+      selectedCounts.set(node.path, count)
+      if (inherited) selectedFileCount += 1
+      return { state: st, count }
+    }
+    let total = 0
+    let anyChecked = false
+    let anyUnchecked = false
+    let anyIndeterminate = false
+    for (const c of node.children) {
+      const r = walk(c, inherited)
+      total += r.count
+      if (r.state === 'checked') anyChecked = true
+      else if (r.state === 'unchecked') anyUnchecked = true
+      else anyIndeterminate = true
+    }
+    let st: NodeState
+    if (inherited) st = 'checked'
+    else if (anyIndeterminate || (anyChecked && anyUnchecked)) st = 'indeterminate'
+    else if (anyChecked) st = 'checked'
+    else st = 'unchecked'
+    states.set(node.path, st)
+    selectedCounts.set(node.path, total)
+    return { state: st, count: total }
+  }
+
+  for (const n of tree) walk(n, false)
+  return { states, selectedCounts, selectedFileCount }
+}
+
+/** Return chain of nodes from top-level ancestor down to the target (inclusive). */
+function findChain(tree: IgnoredFileNode[], targetPath: string): IgnoredFileNode[] | null {
+  for (const node of tree) {
+    if (node.path === targetPath) return [node]
+    if (targetPath.startsWith(node.path + '/')) {
+      const sub = findChain(node.children, targetPath)
+      if (sub) return [node, ...sub]
+    }
+  }
+  return null
+}
+
+function removeSubtree(node: IgnoredFileNode, set: Set<string>): void {
+  set.delete(node.path)
+  for (const c of node.children) removeSubtree(c, set)
+}
+
+function NodeRow({
+  node, depth, states, selectedCounts, expanded, onToggle, onToggleExpand,
+}: {
   node: IgnoredFileNode
   depth: number
+  states: Map<string, NodeState>
+  selectedCounts: Map<string, number>
   expanded: Set<string>
+  onToggle: (path: string) => void
   onToggleExpand: (path: string) => void
 }) {
+  const state = states.get(node.path) ?? 'unchecked'
   const isExpanded = expanded.has(node.path)
+  const checked: boolean | 'indeterminate' =
+    state === 'checked' ? true : state === 'indeterminate' ? 'indeterminate' : false
+  const selectedCount = selectedCounts.get(node.path) ?? 0
+
   return (
     <>
       <div
-        className="flex items-center gap-1.5 py-0.5 text-xs font-mono text-muted-foreground hover:text-foreground transition-colors"
-        style={{ paddingLeft: `${depth * 16 + 4}px` }}
+        className="flex items-center gap-2 py-1 rounded hover:bg-muted transition-colors"
+        style={{ paddingLeft: `${depth * 16 + 8}px`, paddingRight: 8 }}
       >
+        <Checkbox checked={checked} onCheckedChange={() => onToggle(node.path)} />
         {node.isDirectory ? (
-          <button type="button" onClick={() => onToggleExpand(node.path)} className="flex items-center gap-1.5 min-w-0 flex-1 text-left">
-            <ChevronRight className={`h-3 w-3 shrink-0 transition-transform ${isExpanded ? 'rotate-90' : ''}`} />
-            <Folder className="h-3.5 w-3.5 shrink-0 text-blue-400" />
-            <span className="truncate">{node.name}/</span>
-            <span className="ml-auto shrink-0 text-[10px] opacity-70">{node.fileCount} file{node.fileCount !== 1 ? 's' : ''}</span>
+          <button
+            type="button"
+            onClick={() => onToggleExpand(node.path)}
+            className="flex items-center gap-1.5 flex-1 min-w-0 text-left"
+          >
+            <ChevronRight className={cn('h-3.5 w-3.5 text-muted-foreground shrink-0 transition-transform', isExpanded && 'rotate-90')} />
+            <Folder className="h-3.5 w-3.5 text-blue-400 shrink-0" />
+            <span className="text-sm font-mono flex-1 truncate">{node.name}/</span>
+            <span className="text-xs text-muted-foreground shrink-0">
+              {node.fileCount} file{node.fileCount !== 1 ? 's' : ''}
+              {selectedCount > 0 && (
+                <span className="text-primary"> ({selectedCount} selected)</span>
+              )}
+            </span>
           </button>
         ) : (
-          <span className="flex items-center gap-1.5 min-w-0 flex-1">
-            <span className="w-3" />
-            <File className="h-3.5 w-3.5 shrink-0" />
-            <span className="truncate">{node.name}</span>
-            {node.size > 0 && <span className="ml-auto shrink-0 text-[10px] opacity-70">{formatBytes(node.size)}</span>}
+          <span className="flex items-center gap-1.5 flex-1 min-w-0">
+            <span className="w-3.5" />
+            <File className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+            <span className="text-sm font-mono flex-1 truncate">{node.name}</span>
+            {node.size > 0 && (
+              <span className="text-xs text-muted-foreground shrink-0">{formatBytes(node.size)}</span>
+            )}
           </span>
         )}
       </div>
-      {isExpanded && node.children.map(child => (
-        <TreeRow key={child.path} node={child} depth={depth + 1} expanded={expanded} onToggleExpand={onToggleExpand} />
+      {node.isDirectory && isExpanded && node.children.map(child => (
+        <NodeRow
+          key={child.path}
+          node={child}
+          depth={depth + 1}
+          states={states}
+          selectedCounts={selectedCounts}
+          expanded={expanded}
+          onToggle={onToggle}
+          onToggleExpand={onToggleExpand}
+        />
       ))}
     </>
   )
@@ -118,7 +217,6 @@ export function CopyFilesDialog({ open, onOpenChange, repoPath, onConfirm }: Cop
   const [loading, setLoading] = useState(false)
   const [treeLoaded, setTreeLoaded] = useState(false)
 
-  // Load presets + file tree on open
   useEffect(() => {
     if (!open) return
     setExpanded(new Set())
@@ -147,7 +245,6 @@ export function CopyFilesDialog({ open, onOpenChange, repoPath, onConfirm }: Cop
     })
   }, [open, repoPath])
 
-  // Apply preset filter when preset or tree changes
   useEffect(() => {
     if (!treeLoaded || presets.length === 0) return
     const preset = presets.find(p => p.id === selectedPresetId)
@@ -155,23 +252,55 @@ export function CopyFilesDialog({ open, onOpenChange, repoPath, onConfirm }: Cop
     setSelected(filterTreeByGlobs(tree, preset.pathGlobs))
   }, [selectedPresetId, treeLoaded, tree, presets])
 
-  const toggle = useCallback((name: string) => {
+  const { states, selectedCounts, selectedFileCount } = useMemo(
+    () => computeStates(tree, selected),
+    [tree, selected]
+  )
+
+  const toggle = useCallback((path: string) => {
     setSelected(prev => {
+      const state = computeStates(tree, prev).states.get(path) ?? 'unchecked'
+      const chain = findChain(tree, path)
+      if (!chain) return prev
+      const leaf = chain[chain.length - 1]
       const next = new Set(prev)
-      if (next.has(name)) next.delete(name)
-      else next.add(name)
+
+      if (state === 'checked') {
+        // Uncheck — if an ancestor holds the selection, expand it along the chain
+        // so that siblings along the way stay selected but the target's subtree doesn't.
+        let ancestorIdx = -1
+        for (let i = 0; i < chain.length; i++) {
+          if (next.has(chain[i].path)) { ancestorIdx = i; break }
+        }
+        if (ancestorIdx >= 0 && ancestorIdx < chain.length - 1) {
+          next.delete(chain[ancestorIdx].path)
+          for (let i = ancestorIdx; i < chain.length - 1; i++) {
+            const cur = chain[i]
+            const nextInPath = chain[i + 1]
+            for (const child of cur.children) {
+              if (child.path !== nextInPath.path) next.add(child.path)
+            }
+          }
+        }
+        removeSubtree(leaf, next)
+      } else {
+        // Check (from unchecked or indeterminate)
+        removeSubtree(leaf, next)
+        next.add(leaf.path)
+      }
+
       return next
     })
-    // Switching to custom when user manually toggles
     setSelectedPresetId('custom')
-  }, [])
+  }, [tree])
 
   const toggleAll = () => {
-    const allNames = flattenTree(tree)
-    if (selected.size === allNames.length) {
+    const topLevel = tree.map(n => n.path)
+    const allSelected = topLevel.every(p => selected.has(p))
+    if (allSelected && selected.size === topLevel.length) {
       setSelected(new Set())
     } else {
-      setSelected(new Set(allNames))
+      setSelected(new Set(topLevel))
     }
     setSelectedPresetId('custom')
   }
@@ -197,6 +326,8 @@ export function CopyFilesDialog({ open, onOpenChange, repoPath, onConfirm }: Cop
     onConfirm({ mode: 'none' })
   }
 
+  const allTopSelected = tree.length > 0 && tree.every(n => (states.get(n.path) ?? 'unchecked') === 'checked')
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[80vh] max-w-lg flex flex-col">
@@ -208,7 +339,6 @@ export function CopyFilesDialog({ open, onOpenChange, repoPath, onConfirm }: Cop
         </DialogHeader>
 
         <div className="space-y-3">
-          {/* Preset selector */}
           <div className="space-y-1.5">
             <label className="text-xs font-medium text-muted-foreground">Preset</label>
             <Select value={selectedPresetId} onValueChange={setSelectedPresetId}>
@@ -226,7 +356,6 @@ export function CopyFilesDialog({ open, onOpenChange, repoPath, onConfirm }: Cop
             </Select>
           </div>
 
-          {/* File tree */}
           {loading ? (
             <div className="flex flex-col items-center justify-center gap-2 py-8 rounded-lg border bg-muted/20">
               <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
@@ -238,51 +367,34 @@ export function CopyFilesDialog({ open, onOpenChange, repoPath, onConfirm }: Cop
             <div className="flex flex-col gap-2 min-h-0 flex-1">
               <div className="flex items-center justify-between">
                 <span className="text-xs text-muted-foreground">
-                  {selected.size} of {tree.length} selected
+                  {selectedFileCount} file{selectedFileCount !== 1 ? 's' : ''} selected
                 </span>
                 <button type="button" onClick={toggleAll} className="text-xs text-muted-foreground hover:text-foreground transition-colors">
-                  {selected.size === tree.length ? 'Deselect all' : 'Select all'}
+                  {allTopSelected ? 'Deselect all' : 'Select all'}
                 </button>
               </div>
-              <div className="min-h-0 flex-1 overflow-y-auto rounded-lg border p-2 max-h-[40vh]">
+              <div className="min-h-0 flex-1 overflow-y-auto rounded-lg border py-1 max-h-[40vh]">
                 {tree.map(node => (
-                  <div key={node.name}>
-                    <div className="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-muted transition-colors">
-                      <Checkbox
-                        checked={selected.has(node.name)}
-                        onCheckedChange={() => toggle(node.name)}
-                      />
-                      {node.isDirectory ? (
-                        <button type="button" onClick={() => toggleExpand(node.path)} className="flex items-center gap-1.5 flex-1 min-w-0 text-left">
-                          <ChevronRight className={cn('h-3.5 w-3.5 text-muted-foreground shrink-0 transition-transform', expanded.has(node.path) && 'rotate-90')} />
-                          <Folder className="h-3.5 w-3.5 text-blue-400 shrink-0" />
-                          <span className="text-sm font-mono flex-1 truncate">{node.name}/</span>
-                          <span className="text-xs text-muted-foreground shrink-0">{node.fileCount} file{node.fileCount !== 1 ? 's' : ''}</span>
-                        </button>
-                      ) : (
-                        <span className="flex items-center gap-1.5 flex-1 min-w-0">
-                          <span className="w-3.5" />
-                          <File className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-                          <span className="text-sm font-mono flex-1 truncate">{node.name}</span>
-                          {node.size > 0 && <span className="text-xs text-muted-foreground shrink-0">{formatBytes(node.size)}</span>}
-                        </span>
-                      )}
-                    </div>
-                    {expanded.has(node.path) && node.children.map(child => (
-                      <TreeRow key={child.path} node={child} depth={1} expanded={expanded} onToggleExpand={toggleExpand} />
-                    ))}
-                  </div>
+                  <NodeRow
+                    key={node.path}
+                    node={node}
+                    depth={0}
+                    states={states}
+                    selectedCounts={selectedCounts}
+                    expanded={expanded}
+                    onToggle={toggle}
+                    onToggleExpand={toggleExpand}
+                  />
                 ))}
               </div>
             </div>
           )}
         </div>
 
-        {/* Footer */}
         <div className="flex justify-end gap-2 pt-2">
           <Button variant="outline" size="sm" onClick={handleSkip}>Skip</Button>
-          <Button size="sm" onClick={handleConfirm} disabled={selected.size === 0}>
-            Copy {selected.size} item{selected.size !== 1 ? 's' : ''}
+          <Button size="sm" onClick={handleConfirm} disabled={selectedFileCount === 0}>
+            Copy {selectedFileCount} file{selectedFileCount !== 1 ? 's' : ''}
           </Button>
         </div>
       </DialogContent>

--- a/packages/domains/worktrees/src/client/CopyFilesDialog.tsx
+++ b/packages/domains/worktrees/src/client/CopyFilesDialog.tsx
@@ -258,8 +258,8 @@ export function CopyFilesDialog({ open, onOpenChange, repoPath, onConfirm }: Cop
   )
 
   const toggle = useCallback((path: string) => {
+    const state = states.get(path) ?? 'unchecked'
     setSelected(prev => {
-      const state = computeStates(tree, prev).states.get(path) ?? 'unchecked'
       const chain = findChain(tree, path)
       if (!chain) return prev
       const leaf = chain[chain.length - 1]
@@ -292,15 +292,15 @@ export function CopyFilesDialog({ open, onOpenChange, repoPath, onConfirm }: Cop
       return next
     })
     setSelectedPresetId('custom')
-  }, [tree])
+  }, [tree, states])
+
+  const allTopSelected = tree.length > 0 && tree.every(n => (states.get(n.path) ?? 'unchecked') === 'checked')
 
   const toggleAll = () => {
-    const topLevel = tree.map(n => n.path)
-    const allSelected = topLevel.every(p => selected.has(p))
-    if (allSelected && selected.size === topLevel.length) {
+    if (allTopSelected) {
       setSelected(new Set())
     } else {
-      setSelected(new Set(topLevel))
+      setSelected(new Set(tree.map(n => n.path)))
     }
     setSelectedPresetId('custom')
   }
@@ -315,7 +315,7 @@ export function CopyFilesDialog({ open, onOpenChange, repoPath, onConfirm }: Cop
   }, [])
 
   const handleConfirm = () => {
-    if (selected.size === 0) {
+    if (selectedFileCount === 0) {
       onConfirm({ mode: 'none' })
     } else {
       onConfirm({ mode: 'custom', paths: [...selected] })
@@ -325,8 +325,6 @@ export function CopyFilesDialog({ open, onOpenChange, repoPath, onConfirm }: Cop
   const handleSkip = () => {
     onConfirm({ mode: 'none' })
   }
-
-  const allTopSelected = tree.length > 0 && tree.every(n => (states.get(n.path) ?? 'unchecked') === 'checked')
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/packages/shared/ui/src/checkbox.tsx
+++ b/packages/shared/ui/src/checkbox.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import * as CheckboxPrimitive from '@radix-ui/react-checkbox'
-import { CheckIcon } from 'lucide-react'
+import { CheckIcon, MinusIcon } from 'lucide-react'
 
 import { cn } from './utils'
 
@@ -9,7 +9,7 @@ function Checkbox({ className, ...props }: React.ComponentProps<typeof CheckboxP
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        'peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+        'peer group border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary data-[state=indeterminate]:bg-primary data-[state=indeterminate]:text-primary-foreground dark:data-[state=indeterminate]:bg-primary data-[state=indeterminate]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
         className
       )}
       {...props}
@@ -18,7 +18,8 @@ function Checkbox({ className, ...props }: React.ComponentProps<typeof CheckboxP
         data-slot="checkbox-indicator"
         className="grid place-content-center text-current transition-none"
       >
-        <CheckIcon className="size-3.5" />
+        <CheckIcon className="size-3.5 group-data-[state=indeterminate]:hidden" />
+        <MinusIcon className="size-3.5 hidden group-data-[state=indeterminate]:block" />
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>
   )


### PR DESCRIPTION
## Summary
- Preset globs like \`.env*\` now match nested files at any depth (previously only top-level).
- Every node in the tree has a checkbox — users can select/deselect individual files or folders at any depth, with ancestors auto-expanded when a single descendant is unchecked.
- Partially-selected folders render an indeterminate state (minus icon). Row-level counters show \`N files (M selected)\` when any descendants are picked. Header + Copy button show the total selected file count.
- Fixes indeterminate checkbox contrast in dark mode (missing \`dark:\` variant).

## Test plan
- [ ] Open "Copy files to worktree" on a repo with a nested \`.env\` (e.g. \`apps/web/.env\`) and pick the "Env files only" preset — nested envs appear in the selected count and get copied.
- [ ] Partially select a folder by toggling children — parent checkbox shows indeterminate with visible minus icon.
- [ ] Select a top-level folder, then uncheck one nested file — sibling dirs stay selected, the unchecked file is excluded.
- [ ] Copy button label matches total file count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR rewrites the \"Copy files to worktree\" dialog to support recursive file selection: preset globs now match files at any depth, every tree node has a checkbox with indeterminate support, and counters reflect actual file counts rather than selection-root counts. The checkbox component gains a `MinusIcon` + dark-mode contrast fix.

- **P1 — invariant violation in `filterTreeByGlobs`**: The built-in \"Docs + env\" preset (and any user preset mixing directory globs like `docs/**` with basename globs like `.env*`) produces a `selected` set containing both a directory root and its descendant files simultaneously. `handleConfirm` forwards `[...selected]` verbatim, so the backend receives duplicate copy roots for affected files.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

Hold for the P1 mixed-glob invariant bug before merging; the checkbox and tree-interaction logic are otherwise solid.

One P1 defect: the "Docs + env" preset (and any mixed dir+basename glob preset) silently sends redundant paths to the backend, risking duplicate or failed copy operations. All other changes — toggle logic, computeStates, toggleAll fix, and checkbox indeterminate support — are correct.

CopyFilesDialog.tsx — specifically the filterTreeByGlobs function and the handleConfirm path.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/domains/worktrees/src/client/CopyFilesDialog.tsx | Major recursive selection rewrite with a P1 bug: mixed-glob presets (e.g. "Docs + env") can populate `selected` with both a directory root and its descendant files, violating the invariant and sending duplicate paths to the backend on confirm. |
| packages/shared/ui/src/checkbox.tsx | Adds indeterminate state support via `group`/`group-data-[state=indeterminate]` Tailwind classes and a `MinusIcon` toggle — correct implementation, fixes the dark-mode contrast issue. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Preset selected / tree loaded] --> B[filterTreeByGlobs]
    B -->|globs empty| C[Set of top-level paths]
    B -->|single-segment globs| D[Recursive basename walk → leaf file paths]
    B -->|multi-segment globs| E[Top-level dir paths]
    D --> F{⚠️ Overlap?}
    E --> F
    F -->|dir already matched| G[Both dir AND child paths in selected — invariant violated]
    F -->|no overlap| H[selected set — invariant ok]
    G --> I[computeStates — display correct via ancestorSelected]
    H --> I
    I --> J[NodeRow renders checkbox states]
    J -->|user toggles| K[toggle — expands ancestor chain, cleans up via removeSubtree]
    K --> I
    I --> L[handleConfirm — paths: ...selected]
    G --> L
    L -->|invariant violated| M[⚠️ Backend receives duplicate roots]
    L -->|invariant ok| N[Backend copies files correctly]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/domains/worktrees/src/client/CopyFilesDialog.tsx`, line 317-323 ([link](https://github.com/debuglebowski/slayzone/blob/333f4eec0e582de961afead2887a07e83b8acbab/packages/domains/worktrees/src/client/CopyFilesDialog.tsx#L317-L323)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`handleConfirm` guard mismatches the button's disabled condition**

   The Copy button is disabled when `selectedFileCount === 0`, but `handleConfirm` falls back to `mode: 'none'` when `selected.size === 0`. These can diverge: if only empty directories are selected, `selected.size > 0` while `selectedFileCount === 0` — the button stays disabled so the code is never reached today, but a future refactor could expose it. Aligning the guard makes the intent explicit:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/domains/worktrees/src/client/CopyFilesDialog.tsx
   Line: 317-323

   Comment:
   **`handleConfirm` guard mismatches the button's disabled condition**

   The Copy button is disabled when `selectedFileCount === 0`, but `handleConfirm` falls back to `mode: 'none'` when `selected.size === 0`. These can diverge: if only empty directories are selected, `selected.size > 0` while `selectedFileCount === 0` — the button stays disabled so the code is never reached today, but a future refactor could expose it. Aligning the guard makes the intent explicit:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/domains/worktrees/src/client/CopyFilesDialog.tsx
Line: 52-64

Comment:
**Mixed-glob preset violates ancestor/descendant invariant**

`filterTreeByGlobs` adds a directory root (via `dirPrefixes`) and then separately walks all nodes matching basename globs — including files that are descendants of that already-added directory. For the built-in **"Docs + env"** preset (`['docs/**', '.env*', '*.md', '*.local']`), if `docs/.env` exists, `selected` ends up as `{ 'docs', 'docs/.env', 'docs/README.md', … }`. The invariant described in the `computeStates` comment ("no ancestor and descendant appear together") is broken.

The UI appearance remains correct because `computeStates` propagates `ancestorSelected` before checking `selected.has(node.path)`. However, `handleConfirm` passes `[...selected]` verbatim, so the backend receives both `docs` and `docs/.env` as copy roots — likely triggering duplicate copies or errors depending on how the copy operation deduplicates.

Fix: skip the basename walk for nodes whose ancestor is already in `matched`.

```ts
const walk = (node: IgnoredFileNode, ancestorMatched: boolean) => {
  const selfMatched = ancestorMatched || (node.isDirectory && dirPrefixes.includes(node.name))
  if (!node.isDirectory && !ancestorMatched && basenameMatchers.some(re => re.test(node.name))) {
    matched.add(node.path)
  }
  for (const child of node.children) walk(child, selfMatched)
}
for (const node of nodes) walk(node, false)
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/domains/worktrees/src/client/CopyFilesDialog.tsx
Line: 177-182

Comment:
**Counter shows "N files (N selected)" when fully selected**

When a folder is fully checked, `selectedCount === node.fileCount`, so the label reads e.g. "5 files (5 selected)" — redundant since the filled checkbox already communicates full selection. Consider hiding the counter when all files are selected:

```suggestion
            <span className="text-xs text-muted-foreground shrink-0">
              {node.fileCount} file{node.fileCount !== 1 ? 's' : ''}
              {selectedCount > 0 && selectedCount < node.fileCount && (
                <span className="text-primary"> ({selectedCount} selected)</span>
              )}
            </span>
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(worktrees): address copy-files-..."](https://github.com/debuglebowski/slayzone/commit/409c07a4b4ec14e8ee57a6310d5358991b6339c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28995536)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->