### PR TITLE
fix(kanban): restore overflow scrollbars

### DIFF
--- a/packages/apps/app/e2e/core/93-kanban-scrollbars.spec.ts
+++ b/packages/apps/app/e2e/core/93-kanban-scrollbars.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect, seed, goHome, clickProject, resetApp } from '../fixtures/electron'
+import { TEST_PROJECT_PATH } from '../fixtures/electron'
+
+test.describe('Kanban scrollbars', () => {
+  let projectAbbrev: string
+
+  test.beforeAll(async ({ mainWindow }) => {
+    await resetApp(mainWindow)
+    const s = seed(mainWindow)
+    const p = await s.createProject({ name: 'Kanban Scroll', color: '#0ea5e9', path: TEST_PROJECT_PATH })
+    projectAbbrev = p.name.slice(0, 2).toUpperCase()
+
+    for (let i = 1; i <= 24; i++) {
+      await s.createTask({ projectId: p.id, title: `Inbox overflow ${i}`, status: 'inbox' })
+    }
+
+    await s.refreshData()
+    await goHome(mainWindow)
+    await clickProject(mainWindow, projectAbbrev)
+    await expect(mainWindow.locator('h3').getByText('Inbox', { exact: true })).toBeVisible({ timeout: 5_000 })
+  })
+
+  test('board shows usable horizontal overflow only when columns exceed width', async ({ mainWindow, electronApp }) => {
+    await electronApp.evaluate(({ BrowserWindow }) => {
+      const win = BrowserWindow.getAllWindows()[0]
+      win.setSize(900, 800)
+    })
+    await mainWindow.waitForTimeout(500)
+
+    const boardScroller = mainWindow.locator('div.overflow-x-auto').filter({
+      has: mainWindow.locator('h3').getByText('Inbox', { exact: true })
+    }).first()
+
+    const state = await boardScroller.evaluate((el) => {
+      const node = el as HTMLDivElement
+      const before = node.scrollLeft
+      node.scrollLeft = 240
+      return {
+        className: node.className,
+        overflowX: window.getComputedStyle(node).overflowX,
+        scrollWidth: node.scrollWidth,
+        clientWidth: node.clientWidth,
+        scrollLeftBefore: before,
+        scrollLeftAfter: node.scrollLeft
+      }
+    })
+
+    expect(state.className).toContain('scrollbar-thin')
+    expect(state.className).not.toContain('scrollbar-hide')
+    expect(['auto', 'scroll']).toContain(state.overflowX)
+    expect(state.scrollWidth).toBeGreaterThan(state.clientWidth)
+    expect(state.scrollLeftAfter).toBeGreaterThan(state.scrollLeftBefore)
+  })
+
+  test('column shows usable vertical overflow only when cards exceed height', async ({ mainWindow, electronApp }) => {
+    await electronApp.evaluate(({ BrowserWindow }) => {
+      const win = BrowserWindow.getAllWindows()[0]
+      win.setSize(900, 650)
+    })
+    await mainWindow.waitForTimeout(500)
+
+    const inboxColumn = mainWindow.locator('h3').getByText('Inbox', { exact: true })
+      .locator('xpath=ancestor::div[contains(@class,"w-72")]')
+      .first()
+    const inboxScroller = inboxColumn.locator('div.overflow-y-auto').first()
+
+    const state = await inboxScroller.evaluate((el) => {
+      const node = el as HTMLDivElement
+      const before = node.scrollTop
+      node.scrollTop = 320
+      return {
+        className: node.className,
+        overflowY: window.getComputedStyle(node).overflowY,
+        scrollHeight: node.scrollHeight,
+        clientHeight: node.clientHeight,
+        scrollTopBefore: before,
+        scrollTopAfter: node.scrollTop
+      }
+    })
+
+    expect(state.className).toContain('scrollbar-thin')
+    expect(state.className).not.toContain('scrollbar-hide')
+    expect(['auto', 'scroll']).toContain(state.overflowY)
+    expect(state.scrollHeight).toBeGreaterThan(state.clientHeight)
+    expect(state.scrollTopAfter).toBeGreaterThan(state.scrollTopBefore)
+  })
+})

--- a/packages/apps/app/src/renderer/src/assets/main.css
+++ b/packages/apps/app/src/renderer/src/assets/main.css
@@ -734,6 +734,7 @@
 }
 .scrollbar-thin::-webkit-scrollbar {
   width: 6px;
+  height: 6px;
 }
 .scrollbar-thin::-webkit-scrollbar-track {
   background: transparent;

--- a/packages/domains/tasks/src/client/KanbanBoard.tsx
+++ b/packages/domains/tasks/src/client/KanbanBoard.tsx
@@ -228,7 +228,7 @@ export function KanbanBoard({
       onDragEnd={handleDragEnd}
     >
       <div className="relative h-full min-h-0">
-      <div className="flex gap-4 overflow-x-auto pr-16 h-full [&::-webkit-scrollbar]:hidden">
+      <div className="flex h-full min-h-0 min-w-0 gap-4 overflow-x-auto pr-16 scrollbar-thin">
         {visibleColumns.map((column) => (
           <KanbanColumn
             key={column.id}

--- a/packages/domains/tasks/src/client/KanbanColumn.tsx
+++ b/packages/domains/tasks/src/client/KanbanColumn.tsx
@@ -196,7 +196,7 @@ export function KanbanColumn({
     overColumnId === column.id && activeColumnId !== null && activeColumnId !== column.id
 
   return (
-    <div className="flex w-72 shrink-0 flex-col h-full">
+    <div className="flex h-full min-h-0 w-72 shrink-0 flex-col">
       <div className="mb-2 flex items-center justify-between px-2 select-none">
         <div className="flex items-center gap-2">
           {(() => {
@@ -243,7 +243,7 @@ export function KanbanColumn({
       <div
         ref={setNodeRef}
         className={cn(
-          'flex-1 h-full rounded-lg bg-surface-2 p-2 min-h-[200px] overflow-y-auto scrollbar-hide',
+          'flex-1 min-h-0 overflow-y-auto rounded-lg bg-surface-2 p-2 scrollbar-thin',
           showDropHighlight && 'bg-surface-3 ring-2 ring-primary/20'
         )}
       >


### PR DESCRIPTION
**Bug description**
The app is expecting a relatively large screen to operate, but if the window is too small, then no scrollbars are available and it is very difficult to navigate between the Kanban columns. Scrollbars do not appear and content is cropped.
 
<img width="1738" height="816" alt="bug1" src="https://github.com/user-attachments/assets/ca275c0f-1c1b-463f-b157-68143050d5b7" />

Scrollbars support was restored in this view such that the user can scroll horizontally through all columns. 
<img width="1669" height="661" alt="fix1" src="https://github.com/user-attachments/assets/0ee1afd4-67ec-4ef2-85b4-c2fa25bb0d8c" />

For vertical scrolling, the scrollbar is per Kanban column. 
<img width="1668" height="439" alt="fix2" src="https://github.com/user-attachments/assets/200dadf7-baee-4c32-b1fe-432efebd28a2" />

 Co-authored-by: Copilot GPT 5.4

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR restores horizontal and vertical scrollbars on the Kanban board by replacing `scrollbar-hide` with `scrollbar-thin`, adding `min-h-0`/`min-w-0` so flex containers can actually shrink and scroll, and adding `height: 6px` to the webkit scrollbar CSS rule so the horizontal track renders correctly. A new e2e spec validates both scroll axes at a constrained window size.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — targeted, well-tested CSS/layout fix with no functional regressions.

All findings are P2 style suggestions on the test file. The production code changes are minimal and correct: `min-h-0` is the standard flexbox fix for overflow scrolling, and replacing `scrollbar-hide` with `scrollbar-thin` directly addresses the reported bug.

packages/apps/app/e2e/core/93-kanban-scrollbars.spec.ts — minor test fragility (hardcoded timeout, XPath tied to Tailwind class).
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/apps/app/e2e/core/93-kanban-scrollbars.spec.ts | New e2e spec verifying horizontal board scroll and vertical column scroll; uses hardcoded timeouts and an XPath selector tied to a Tailwind class, making it mildly fragile on slow CI. |
| packages/apps/app/src/renderer/src/assets/main.css | Added `height: 6px` to `.scrollbar-thin::-webkit-scrollbar` so the horizontal scrollbar track renders at the correct thickness; correct and minimal change. |
| packages/domains/tasks/src/client/KanbanBoard.tsx | Board scroll container: replaced `[&::-webkit-scrollbar]:hidden` with `scrollbar-thin` and added `min-h-0 min-w-0` to allow flexbox shrinking — correct fix. |
| packages/domains/tasks/src/client/KanbanColumn.tsx | Column root and scroll container: added `min-h-0` and replaced `scrollbar-hide` with `scrollbar-thin`; also removed `min-h-[200px]` guard — safe because `flex-1` with a bounded parent height handles the empty-column case. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["DndContext (KanbanBoard)"]
    A --> B["div.relative.h-full.min-h-0"]
    B --> C["div.flex.h-full.min-h-0.min-w-0\n overflow-x-auto.scrollbar-thin\n(horizontal scroll)"]
    C --> D["KanbanColumn (×N)\ndiv.flex.h-full.min-h-0.w-72.shrink-0.flex-col"]
    D --> E["Column header (h3 + controls)"]
    D --> F["div.flex-1.min-h-0.overflow-y-auto\n.scrollbar-thin\n(vertical scroll per column)"]
    F --> G["Task cards"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/apps/app/e2e/core/93-kanban-scrollbars.spec.ts
Line: 28

Comment:
**Hardcoded `waitForTimeout` is fragile**

`waitForTimeout(500)` is a fixed sleep that races against the OS actually resizing the window. On a slow CI runner the resize may not have completed in 500 ms, causing intermittent failures. Prefer polling for a computed style or scroll-width change instead.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/apps/app/e2e/core/93-kanban-scrollbars.spec.ts
Line: 67-70

Comment:
**XPath ancestor selector tied to a Tailwind utility class**

`ancestor::div[contains(@class,"w-72")]` couples the test to the specific Tailwind width utility class. If the column width is ever changed (e.g. to `w-80` or a CSS variable), this selector silently returns no element and the test would fail with a confusing error. Consider adding a `data-testid="kanban-column"` attribute to the column root div and using that instead.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(kanban): restore overflow scrollbars"](https://github.com/debuglebowski/slayzone/commit/1772594761576d7296f86dc604c4221208ffed32) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29331137)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->