### PR TITLE
feat(file-editor): render mermaid diagrams in markdown split view

### DIFF
--- a/packages/domains/file-editor/package.json
+++ b/packages/domains/file-editor/package.json
@@ -54,6 +54,7 @@
     "ignore": "^5.3.2",
     "lezer-toml": "^1.0.0",
     "lucide-react": "^0.562.0",
+    "mermaid": "^11.13.0",
     "react-markdown": "^10.1.0",
     "remark-frontmatter": "^5.0.0",
     "remark-gfm": "^4.0.1"

--- a/packages/domains/file-editor/src/client/MarkdownSplitView.tsx
+++ b/packages/domains/file-editor/src/client/MarkdownSplitView.tsx
@@ -1,9 +1,22 @@
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
-import type { CSSProperties } from 'react'
+import { isValidElement, useState, useEffect, type CSSProperties, type ReactElement, type ReactNode } from 'react'
+import { MermaidBlock } from './MermaidBlock'
 import { useTheme } from '@slayzone/settings/client'
 import { getThemeEditorColors, useAppearance } from '@slayzone/ui'
 import { CodeEditor } from './CodeEditor'
+
+const markdownComponents = {
+  pre({ children }: { children?: ReactNode }) {
+    if (isValidElement(children)) {
+      const child = children as ReactElement<{ className?: string; children?: ReactNode }>
+      if (child.props?.className === 'language-mermaid') {
+        return <MermaidBlock code={String(child.props.children ?? '').replace(/\n$/, '')} />
+      }
+    }
+    return <pre>{children}</pre>
+  },
+}
 
 interface MarkdownSplitViewProps {
   filePath: string
@@ -19,6 +32,14 @@ export function MarkdownSplitView({ filePath, content, onChange, onSave, version
   const { editorThemeId, contentVariant } = useTheme()
   const colors = getThemeEditorColors(editorThemeId, contentVariant)
   const { notesReadability, notesWidth } = useAppearance()
+
+  // Debounce preview updates so ReactMarkdown (and MermaidBlock) only re-render
+  // when typing pauses — eliminates diagram flicker from positional remounts
+  const [previewContent, setPreviewContent] = useState(content)
+  useEffect(() => {
+    const timer = setTimeout(() => setPreviewContent(content), 300)
+    return () => clearTimeout(timer)
+  }, [content])
 
   const themeStyle = {
     '--mk-bg': colors.background,
@@ -48,7 +69,9 @@ export function MarkdownSplitView({ filePath, content, onChange, onSave, version
         <div className="mk-doc" data-readability={notesReadability} data-width={notesWidth} style={themeStyle}>
           <div className="mk-doc-scroll">
             <div className="mk-doc-body">
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+              <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+                {previewContent}
+              </ReactMarkdown>
             </div>
           </div>
         </div>

--- a/packages/domains/file-editor/src/client/MermaidBlock.tsx
+++ b/packages/domains/file-editor/src/client/MermaidBlock.tsx
@@ -1,0 +1,203 @@
+import { useState, useEffect, useLayoutEffect, useRef } from 'react'
+
+// --- Mermaid lazy loader ---
+
+let mermaidModule: typeof import('mermaid')['default'] | null = null
+let mermaidTheme: string | null = null
+let mermaidIdCounter = 0
+
+async function getMermaid(dark: boolean) {
+  const theme = dark ? 'dark' : 'default'
+  if (!mermaidModule) {
+    const mod = await import('mermaid')
+    mermaidModule = mod.default
+    mermaidModule.initialize({ startOnLoad: false, theme, securityLevel: 'loose' })
+    mermaidTheme = theme
+  } else if (mermaidTheme !== theme) {
+    mermaidModule.initialize({ startOnLoad: false, theme, securityLevel: 'loose' })
+    mermaidTheme = theme
+  }
+  return mermaidModule
+}
+
+// Cache SVG by code string — instant re-display when typing other parts of doc
+const svgCache = new Map<string, string>()
+
+// --- Pan/zoom controls ---
+
+const PAN_STEP = 50
+const ZOOM_STEP = 0.25
+const DEFAULT_ZOOM = 0.75
+const MIN_ZOOM = 0.25
+const MAX_ZOOM = 4
+
+const ICON = {
+  chevronUp: '<polyline points="18 15 12 9 6 15"/>',
+  chevronDown: '<polyline points="6 9 12 15 18 9"/>',
+  chevronLeft: '<polyline points="15 18 9 12 15 6"/>',
+  chevronRight: '<polyline points="9 18 15 12 9 6"/>',
+  zoomIn: '<circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/><line x1="11" y1="8" x2="11" y2="14"/><line x1="8" y1="11" x2="14" y2="11"/>',
+  zoomOut: '<circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/><line x1="8" y1="11" x2="14" y2="11"/>',
+  rotateCcw: '<path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/>',
+  moveHorizontal: '<polyline points="18 8 22 12 18 16"/><polyline points="6 8 2 12 6 16"/><line x1="2" y1="12" x2="22" y2="12"/>',
+  copy: '<rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>',
+} as const
+
+function createControlButton(label: string, iconPath: string, onClick: () => void) {
+  const btn = document.createElement('button')
+  btn.title = label
+  btn.className =
+    'flex items-center justify-center w-7 h-7 rounded border bg-background/80 text-muted-foreground hover:text-foreground hover:bg-muted transition-colors'
+  btn.innerHTML = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">${iconPath}</svg>`
+  btn.addEventListener('click', (e) => { e.preventDefault(); e.stopPropagation(); onClick() })
+  return btn
+}
+
+async function copyDiagramAsImage(svgEl: SVGSVGElement) {
+  const svgClone = svgEl.cloneNode(true) as SVGSVGElement
+  svgClone.style.backgroundColor = document.documentElement.classList.contains('dark') ? '#1e1e1e' : '#ffffff'
+  const data = new XMLSerializer().serializeToString(svgClone)
+  const blob = new Blob([data], { type: 'image/svg+xml' })
+  const url = URL.createObjectURL(blob)
+  const img = new Image()
+  await new Promise<void>((resolve, reject) => {
+    img.onload = () => {
+      const canvas = document.createElement('canvas')
+      canvas.width = img.naturalWidth * 2
+      canvas.height = img.naturalHeight * 2
+      const ctx = canvas.getContext('2d')!
+      ctx.scale(2, 2)
+      ctx.drawImage(img, 0, 0)
+      URL.revokeObjectURL(url)
+      canvas.toBlob((b) => {
+        if (b) navigator.clipboard.write([new ClipboardItem({ 'image/png': b })]).then(resolve, reject)
+        else reject(new Error('toBlob returned null'))
+      })
+    }
+    img.onerror = reject
+    img.src = url
+  })
+}
+
+function attachControls(container: HTMLElement, svgEl: SVGSVGElement) {
+  let zoom = DEFAULT_ZOOM
+  let panX = 0
+  let panY = 0
+  let fitWidth = false
+
+  const viewport = document.createElement('div')
+  viewport.className = 'overflow-hidden relative'
+  const inner = document.createElement('div')
+  inner.className = 'transition-transform duration-150 origin-center'
+  inner.style.willChange = 'transform'
+  inner.appendChild(svgEl)
+  viewport.appendChild(inner)
+  container.insertBefore(viewport, container.firstChild)
+  applyTransform()
+
+  function applyTransform() {
+    if (fitWidth) {
+      inner.style.transform = ''
+      inner.style.width = '100%'
+      svgEl.style.width = '100%'
+      svgEl.style.maxWidth = '100%'
+    } else {
+      inner.style.width = ''
+      svgEl.style.width = ''
+      svgEl.style.maxWidth = '100%'
+      inner.style.transform = `scale(${zoom}) translate(${panX}px, ${panY}px)`
+    }
+  }
+
+  function pan(dx: number, dy: number) { fitWidth = false; panX += dx / zoom; panY += dy / zoom; applyTransform() }
+  function zoomBy(delta: number) { fitWidth = false; zoom = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, zoom + delta)); applyTransform() }
+  function reset() { zoom = DEFAULT_ZOOM; panX = 0; panY = 0; fitWidth = false; applyTransform() }
+
+  const controls = document.createElement('div')
+  controls.className = 'absolute top-2 right-2 grid grid-cols-3 gap-0.5 z-10 opacity-0 group-hover:opacity-100 transition-opacity'
+
+  controls.appendChild(createControlButton('Fit width', ICON.moveHorizontal,
+    () => { fitWidth = !fitWidth; if (fitWidth) { zoom = DEFAULT_ZOOM; panX = 0; panY = 0 }; applyTransform() }))
+  controls.appendChild(createControlButton('Pan up', ICON.chevronUp, () => pan(0, PAN_STEP)))
+  controls.appendChild(createControlButton('Zoom in', ICON.zoomIn, () => zoomBy(ZOOM_STEP)))
+  controls.appendChild(createControlButton('Pan left', ICON.chevronLeft, () => pan(PAN_STEP, 0)))
+  controls.appendChild(createControlButton('Reset', ICON.rotateCcw, reset))
+  controls.appendChild(createControlButton('Pan right', ICON.chevronRight, () => pan(-PAN_STEP, 0)))
+  controls.appendChild(createControlButton('Copy as image', ICON.copy,
+    () => { copyDiagramAsImage(svgEl).catch(() => {}) }))
+  controls.appendChild(createControlButton('Pan down', ICON.chevronDown, () => pan(0, -PAN_STEP)))
+  controls.appendChild(createControlButton('Zoom out', ICON.zoomOut, () => zoomBy(-ZOOM_STEP)))
+
+  container.appendChild(controls)
+}
+
+// --- Component ---
+
+export function MermaidBlock({ code }: { code: string }) {
+  const [svg, setSvg] = useState<string | null>(() => svgCache.get(code) ?? null)
+  const [hasError, setHasError] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  // Attach pan/zoom controls after SVG is injected into DOM
+  useLayoutEffect(() => {
+    if (!svg || !containerRef.current) return
+    const svgEl = containerRef.current.querySelector('svg') as SVGSVGElement | null
+    if (!svgEl) return
+    svgEl.style.maxWidth = '100%'
+    svgEl.removeAttribute('height')
+    svgEl.style.backgroundColor = 'transparent'
+    attachControls(containerRef.current, svgEl)
+  }, [svg])
+
+  useEffect(() => {
+    // Cached — render instantly, no flicker
+    const cached = svgCache.get(code)
+    if (cached !== undefined) {
+      setSvg(cached)
+      setHasError(false)
+      return
+    }
+
+    let cancelled = false
+    setHasError(false)
+
+    const dark = document.documentElement.classList.contains('dark')
+    getMermaid(dark).then(async (m) => {
+      const id = `mermaid-fe-${++mermaidIdCounter}`
+      const { svg: rendered } = await m.render(id, code)
+      if (!cancelled) {
+        if (rendered) {
+          svgCache.set(code, rendered)
+          setSvg(rendered)
+        } else {
+          setHasError(true)
+        }
+      }
+    }).catch((err) => {
+      console.warn('[MermaidBlock] render failed:', err)
+      if (!cancelled) setHasError(true)
+    })
+
+    return () => { cancelled = true }
+  }, [code])
+
+  if (hasError) {
+    return (
+      <pre className="text-[11px] bg-muted rounded-md p-3 overflow-x-auto text-foreground">
+        <code>{code}</code>
+      </pre>
+    )
+  }
+
+  if (!svg) {
+    return <div className="my-2 h-12 rounded-md bg-muted/30 animate-pulse" />
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className="my-2 overflow-hidden rounded-md border bg-muted/30 p-4 relative group"
+      dangerouslySetInnerHTML={{ __html: svg }}
+    />
+  )
+}

--- a/packages/domains/file-editor/src/client/MermaidBlock.tsx
+++ b/packages/domains/file-editor/src/client/MermaidBlock.tsx
@@ -6,22 +6,25 @@ let mermaidModule: typeof import('mermaid')['default'] | null = null
 let mermaidTheme: string | null = null
 let mermaidIdCounter = 0
 
+// Cache SVG by code string — instant re-display when typing other parts of doc
+// Capped at 50 entries (FIFO) to prevent unbounded memory growth
+const MAX_CACHE = 50
+const svgCache = new Map<string, string>()
+
 async function getMermaid(dark: boolean) {
   const theme = dark ? 'dark' : 'default'
   if (!mermaidModule) {
     const mod = await import('mermaid')
     mermaidModule = mod.default
-    mermaidModule.initialize({ startOnLoad: false, theme, securityLevel: 'loose' })
+    mermaidModule.initialize({ startOnLoad: false, theme, securityLevel: 'strict' })
     mermaidTheme = theme
   } else if (mermaidTheme !== theme) {
-    mermaidModule.initialize({ startOnLoad: false, theme, securityLevel: 'loose' })
+    svgCache.clear()
+    mermaidModule.initialize({ startOnLoad: false, theme, securityLevel: 'strict' })
     mermaidTheme = theme
   }
   return mermaidModule
 }
-
-// Cache SVG by code string — instant re-display when typing other parts of doc
-const svgCache = new Map<string, string>()
 
 // --- Pan/zoom controls ---
 
@@ -167,6 +170,7 @@ export function MermaidBlock({ code }: { code: string }) {
       const { svg: rendered } = await m.render(id, code)
       if (!cancelled) {
         if (rendered) {
+          if (svgCache.size >= MAX_CACHE) svgCache.delete(svgCache.keys().next().value!)
           svgCache.set(code, rendered)
           setSvg(rendered)
         } else {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -549,6 +549,9 @@ importers:
       lucide-react:
         specifier: ^0.562.0
         version: 0.562.0(react@19.2.3)
+      mermaid:
+        specifier: ^11.13.0
+        version: 11.13.0
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.8)(react@19.2.3)


### PR DESCRIPTION
## Summary

- Adds `MermaidBlock` component to `@slayzone/file-editor` — lazy-loads mermaid, renders diagrams to SVG with pan/zoom/copy controls, caches by code string for instant re-display on re-render
- Wires mermaid into `MarkdownSplitView` via a stable module-level `components` map (prevents react-markdown from remounting on every keystroke)
- Adds 300ms debounce on preview content to eliminate flicker from positional remounts during active typing

## Test plan

- [ ] Open a `.md` file in split view mode (columns icon)
- [ ] Add a mermaid code fence and verify diagram renders after typing pauses
- [ ] Type in non-mermaid content and verify diagram stays stable (no flicker)
- [ ] Hover diagram to confirm pan/zoom/copy controls appear
- [ ] Verify invalid mermaid code falls back to a plain code block

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a `MermaidBlock` component to the file-editor that lazy-loads mermaid, renders diagrams to SVG with a 50-entry FIFO cache and pan/zoom/copy controls, and wires it into `MarkdownSplitView` via a stable module-level `components` map with a 300ms debounce to prevent flicker. The implementation is well-structured with proper cleanup (`cancelled` flag, cache eviction, theme re-init clearing the cache), and the previously flagged `securityLevel: 'loose'` and stale-theme-cache concerns appear to have been addressed.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all remaining findings are P2 quality/UX improvements that don't block correctness.

The two open findings are P2: a rare object-URL leak on copy failure and a silent catch on the copy button. Both are minor and don't affect the core diagram rendering or editor functionality. Prior P0/P1 concerns (securityLevel, stale cache on theme switch, unbounded cache) have been addressed in this revision.

packages/domains/file-editor/src/client/MermaidBlock.tsx — copyDiagramAsImage error handling (lines 66–82 and 129–130).
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/domains/file-editor/src/client/MermaidBlock.tsx | New component — lazy-loads mermaid, renders SVGs with a 50-entry FIFO cache and pan/zoom controls; two P2 issues: object URL leak on copy error and silent copy failure swallowed by empty catch. |
| packages/domains/file-editor/src/client/MarkdownSplitView.tsx | Wires MermaidBlock into ReactMarkdown via a stable module-level components map and adds a 300ms debounce on preview content to prevent diagram flicker; no issues found. |
| packages/domains/file-editor/package.json | Adds mermaid ^11.13.0 as a dependency; straightforward change. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant MarkdownSplitView
    participant MermaidBlock
    participant svgCache
    participant mermaid

    User->>MarkdownSplitView: types in editor
    MarkdownSplitView->>MarkdownSplitView: debounce 300ms
    MarkdownSplitView->>MermaidBlock: render(code)

    alt SVG in cache
        MermaidBlock->>svgCache: get(code)
        svgCache-->>MermaidBlock: cached SVG
        MermaidBlock->>MermaidBlock: setSvg(cached) — instant
    else SVG not cached
        MermaidBlock->>MermaidBlock: show skeleton pulse
        MermaidBlock->>mermaid: getMermaid(dark)
        mermaid-->>MermaidBlock: initialized module
        MermaidBlock->>mermaid: render(id, code)
        mermaid-->>MermaidBlock: SVG string
        MermaidBlock->>svgCache: set(code, svg) [FIFO cap 50]
        MermaidBlock->>MermaidBlock: setSvg(rendered)
    end

    MermaidBlock->>MermaidBlock: useLayoutEffect → attachControls(svgEl)
    MermaidBlock-->>User: diagram + pan/zoom/copy controls
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/domains/file-editor/src/client/MermaidBlock.tsx
Line: 66-82

Comment:
**Object URL leaked on image-load failure**

`URL.revokeObjectURL(url)` is only called inside `img.onload`. If `img.onerror` fires (e.g. the browser can't parse the serialized SVG), the blob URL is never revoked and leaks for the session lifetime. Add a `finally`-style revoke in the error path.

```suggestion
  await new Promise<void>((resolve, reject) => {
    img.onload = () => {
      const canvas = document.createElement('canvas')
      canvas.width = img.naturalWidth * 2
      canvas.height = img.naturalHeight * 2
      const ctx = canvas.getContext('2d')!
      ctx.scale(2, 2)
      ctx.drawImage(img, 0, 0)
      URL.revokeObjectURL(url)
      canvas.toBlob((b) => {
        if (b) navigator.clipboard.write([new ClipboardItem({ 'image/png': b })]).then(resolve, reject)
        else reject(new Error('toBlob returned null'))
      })
    }
    img.onerror = (err) => { URL.revokeObjectURL(url); reject(err) }
    img.src = url
  })
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: packages/domains/file-editor/src/client/MermaidBlock.tsx
Line: 129-130

Comment:
**Copy failure is silently swallowed**

`.catch(() => {})` discards all errors — clipboard permission denial, unsupported `ClipboardItem`, `toBlob` failure, etc. — with zero user feedback. A user clicking "Copy as image" and nothing happening (no toast, no console message) is a confusing experience. At minimum, log the error; ideally surface a brief notification.

```suggestion
    () => { copyDiagramAsImage(svgEl).catch((err) => { console.warn('[MermaidBlock] copy failed:', err) }) }))
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(file-editor): address mermaid securi..."](https://github.com/debuglebowski/slayzone/commit/098832068b663f0b63d75b160082aa8ac2a819ef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29332210)</sub>

<!-- /greptile_comment -->