### PR TITLE
fix(task): drop wheel-zoom wrapper for mermaid asset preview

### DIFF
--- a/packages/domains/task/src/client/AssetsPanel.tsx
+++ b/packages/domains/task/src/client/AssetsPanel.tsx
@@ -455,7 +455,9 @@ function AssetPreview({ renderMode, content, zoomLevel = 1, onZoom }: { renderMo
   const zoomStyle = zoomLevel !== 1 ? { transform: `scale(${zoomLevel})`, transformOrigin: 'top left' } : undefined
 
   if (renderMode === 'svg-preview') return <div className="flex-1 p-4 overflow-auto" onWheel={handleWheel}><div style={zoomStyle} dangerouslySetInnerHTML={{ __html: content }} /></div>
-  if (renderMode === 'mermaid-preview' && content.trim()) return <div className="flex-1 p-4 overflow-auto" onWheel={handleWheel}><div style={zoomStyle}><MermaidBlock code={content} /></div></div>
+  // mermaid-preview: MermaidBlock owns its own zoom/pan controls, so skip the
+  // outer wheel-zoom wrapper to avoid two stacked zoom systems.
+  if (renderMode === 'mermaid-preview' && content.trim()) return <div className="flex-1 p-4 overflow-auto"><MermaidBlock code={content} /></div>
   return null
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #81. AssetsPanel's `mermaid-preview` mode wrapped the new shared `<MermaidBlock>` in the panel's existing Cmd+wheel zoom container, producing two stacked zoom systems with independent state. Drop the wrapper for `mermaid-preview` only — block's own pan/zoom buttons own it. SVG preview keeps the wheel-zoom (no built-in controls there).

Verified:
- \`pnpm -F @slayzone/task typecheck\` clean
- \`pnpm build\` (full electron-vite prod build) clean — also validates #80/#81 in production bundling for the first time

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes the outer Cmd+wheel zoom wrapper that was incorrectly applied to the `mermaid-preview` render mode in `AssetPreview`, after #81 introduced a shared `MermaidBlock` with its own built-in pan/zoom button controls. The `svg-preview` path is unchanged and retains wheel-zoom since it has no built-in controls.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — minimal, targeted fix with no regressions introduced.

Single-line change that removes a clearly incorrect double-zoom wrapper. MermaidBlock's own zoom/pan controls are confirmed present. The svg-preview path is unaffected. No logic or data flow changes.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/domains/task/src/client/AssetsPanel.tsx | Drops the outer `onWheel`/`zoomStyle` wrapper for `mermaid-preview` only; `svg-preview` is unchanged. The `MermaidBlock` component confirmed to own its own zoom/pan state and controls. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    AP["AssetPreview"]
    AP -->|renderMode = html-preview| HTML["<iframe> (no zoom)"]
    AP -->|renderMode = svg-preview| SVG["div + onWheel handler\n+ zoomStyle applied\n(outer wheel-zoom)"]
    AP -->|renderMode = mermaid-preview| MERMAID["div (no onWheel, no zoomStyle)\n└─ MermaidBlock"]
    MERMAID --> MB["MermaidBlock\n(owns zoom/pan state:\nzoomBy, pan, reset,\nfitWidth buttons)"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(task): drop wheel-zoom wrapper for m..."](https://github.com/debuglebowski/slayzone/commit/9b7332c5708eee01a78df53b6892d8a443e77cb4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29730916)</sub>

<!-- /greptile_comment -->