### PR TITLE
feat(automations): add AI action type alongside run_command

### DIFF
--- a/packages/domains/automations/src/client/AutomationDialog.tsx
+++ b/packages/domains/automations/src/client/AutomationDialog.tsx
@@ -12,6 +12,7 @@ interface AiProviderOption {
   id: string
   label: string
   type: string
+  defaultFlags: string
 }
 
 interface AutomationDialogProps {
@@ -92,11 +93,15 @@ function toggleValue(arr: string[], val: string): string[] {
 const EMPTY_TRIGGER: TriggerConfig = { type: 'task_status_change', params: {} }
 const EMPTY_RUN_COMMAND: ActionConfig = { type: 'run_command', params: { command: '' } }
 
-function actionIsValid(action: ActionConfig): boolean {
-  if (action.type === 'ai') {
-    return !!(action.params.provider as string)?.trim() && !!(action.params.prompt as string)?.trim()
+function newAiAction(provider: AiProviderOption | undefined): ActionConfig {
+  return {
+    type: 'ai',
+    params: {
+      provider: provider?.id ?? '',
+      prompt: '',
+      flags: provider?.defaultFlags ?? '',
+    },
   }
-  return !!(action.params.command as string)?.trim()
 }
 
 export function AutomationDialog({ open, onOpenChange, automation, projectId, tags, onSave }: AutomationDialogProps) {
@@ -107,17 +112,40 @@ export function AutomationDialog({ open, onOpenChange, automation, projectId, ta
   const [actions, setActions] = useState<ActionConfig[]>([{ ...EMPTY_RUN_COMMAND }])
   const [showAllVars, setShowAllVars] = useState(false)
   const [providers, setProviders] = useState<AiProviderOption[]>([])
+  const [providersLoaded, setProvidersLoaded] = useState(false)
 
   useEffect(() => {
     if (!open) return
-    window.api.terminalModes.list().then((modes: { id: string; label: string; type: string; enabled: boolean }[]) => {
+    setProvidersLoaded(false)
+    window.api.terminalModes.list().then((modes: { id: string; label: string; type: string; enabled: boolean; defaultFlags?: string | null }[]) => {
       setProviders(
         modes
           .filter(m => m.enabled && getHeadlessPattern(m.type))
-          .map(m => ({ id: m.id, label: m.label, type: m.type }))
+          .map(m => ({ id: m.id, label: m.label, type: m.type, defaultFlags: m.defaultFlags ?? '' }))
       )
-    }).catch(() => setProviders([]))
+      setProvidersLoaded(true)
+    }).catch(() => {
+      setProviders([])
+      setProvidersLoaded(true)
+    })
   }, [open])
+
+  // Validity is provider-aware: an AI action with a stale/disabled provider id
+  // fails validation so the Save button disables and the engine never runs it.
+  // While providers haven't loaded yet, skip the existence check to avoid
+  // flickering Save disabled when editing an existing automation.
+  const actionIsValid = (action: ActionConfig): boolean => {
+    if (action.type === 'ai') {
+      const providerId = (action.params.provider as string)?.trim()
+      if (!providerId) return false
+      if (!(action.params.prompt as string)?.trim()) return false
+      if (providersLoaded && !providers.some(p => p.id === providerId)) return false
+      // Mirror the engine's shell-injection guard so Save disables locally.
+      if (((action.params.flags as string) ?? '').includes('{{')) return false
+      return true
+    }
+    return !!(action.params.command as string)?.trim()
+  }
 
   useEffect(() => {
     if (automation) {
@@ -376,7 +404,7 @@ export function AutomationDialog({ open, onOpenChange, automation, projectId, ta
                   size="sm"
                   className="h-6 text-xs"
                   disabled={providers.length === 0}
-                  onClick={() => setActions((prev: ActionConfig[]) => [...prev, { type: 'ai', params: { provider: providers[0]?.id ?? '', prompt: '', flags: '' } }])}
+                  onClick={() => setActions((prev: ActionConfig[]) => [...prev, newAiAction(providers[0])])}
                 >
                   <Sparkles className="w-3 h-3 mr-1" /> AI
                 </Button>
@@ -390,10 +418,15 @@ export function AutomationDialog({ open, onOpenChange, automation, projectId, ta
                 setActions((prev: ActionConfig[]) => prev.map((a: ActionConfig, j: number) => {
                   if (j !== i) return a
                   if (newType === a.type) return a
-                  return newType === 'ai'
-                    ? { type: 'ai', params: { provider: providers[0]?.id ?? '', prompt: '', flags: '' } }
-                    : { ...EMPTY_RUN_COMMAND }
+                  return newType === 'ai' ? newAiAction(providers[0]) : { ...EMPTY_RUN_COMMAND }
                 }))
+
+              const storedProviderId = action.type === 'ai' ? ((action.params.provider as string) ?? '') : ''
+              const providerMissing = action.type === 'ai'
+                && providersLoaded
+                && !!storedProviderId
+                && !providers.some(p => p.id === storedProviderId)
+              const flagsHasTemplate = action.type === 'ai' && ((action.params.flags as string) ?? '').includes('{{')
 
               return (
                 <div key={i} className="rounded-md border border-border/40 bg-background/40 p-2 space-y-2">
@@ -407,7 +440,7 @@ export function AutomationDialog({ open, onOpenChange, automation, projectId, ta
                     </Select>
                     {action.type === 'ai' && (
                       <Select
-                        value={(action.params.provider as string) || providers[0]?.id || ''}
+                        value={storedProviderId}
                         onValueChange={(v) => updateParam('provider', v)}
                       >
                         <SelectTrigger size="sm" className="flex-1"><SelectValue placeholder="Pick provider" /></SelectTrigger>
@@ -423,6 +456,12 @@ export function AutomationDialog({ open, onOpenChange, automation, projectId, ta
                       </Button>
                     )}
                   </div>
+
+                  {providerMissing && (
+                    <p className="text-[11px] text-destructive">
+                      Provider "{storedProviderId}" is unavailable — pick another above.
+                    </p>
+                  )}
 
                   {action.type === 'run_command' ? (
                     <Textarea
@@ -442,9 +481,14 @@ export function AutomationDialog({ open, onOpenChange, automation, projectId, ta
                       <Input
                         value={(action.params.flags as string) ?? ''}
                         onChange={(e) => updateParam('flags', e.target.value)}
-                        placeholder="extra flags (optional, overrides provider defaults)"
+                        placeholder="provider flags (clear to run with no flags)"
                         className="font-mono text-[11px] h-7"
                       />
+                      {flagsHasTemplate && (
+                        <p className="text-[11px] text-destructive">
+                          Template variables are not allowed in flags — put them in the prompt above.
+                        </p>
+                      )}
                     </>
                   )}
                 </div>

--- a/packages/domains/automations/src/client/AutomationDialog.tsx
+++ b/packages/domains/automations/src/client/AutomationDialog.tsx
@@ -5,8 +5,14 @@ import {
   Select, SelectTrigger, SelectValue, SelectContent, SelectItem, SelectGroup, SelectLabel,
   taskStatusOptions,
 } from '@slayzone/ui'
-import { Plus, Trash2 } from 'lucide-react'
-import { TEMPLATE_VARIABLES, type Automation, type TriggerConfig, type ConditionConfig, type ActionConfig, type CreateAutomationInput, type UpdateAutomationInput } from '@slayzone/automations/shared'
+import { Plus, Trash2, Sparkles, Terminal } from 'lucide-react'
+import { TEMPLATE_VARIABLES, getHeadlessPattern, type Automation, type TriggerConfig, type ConditionConfig, type ActionConfig, type ActionType, type CreateAutomationInput, type UpdateAutomationInput } from '@slayzone/automations/shared'
+
+interface AiProviderOption {
+  id: string
+  label: string
+  type: string
+}
 
 interface AutomationDialogProps {
   open: boolean
@@ -84,14 +90,34 @@ function toggleValue(arr: string[], val: string): string[] {
 }
 
 const EMPTY_TRIGGER: TriggerConfig = { type: 'task_status_change', params: {} }
+const EMPTY_RUN_COMMAND: ActionConfig = { type: 'run_command', params: { command: '' } }
+
+function actionIsValid(action: ActionConfig): boolean {
+  if (action.type === 'ai') {
+    return !!(action.params.provider as string)?.trim() && !!(action.params.prompt as string)?.trim()
+  }
+  return !!(action.params.command as string)?.trim()
+}
 
 export function AutomationDialog({ open, onOpenChange, automation, projectId, tags, onSave }: AutomationDialogProps) {
   const [name, setName] = useState('')
   const [description, setDescription] = useState('')
   const [trigger, setTrigger] = useState<TriggerConfig>(EMPTY_TRIGGER)
   const [conditions, setConditions] = useState<ConditionConfig[]>([])
-  const [actions, setActions] = useState<ActionConfig[]>([{ type: 'run_command', params: { command: '' } }])
+  const [actions, setActions] = useState<ActionConfig[]>([{ ...EMPTY_RUN_COMMAND }])
   const [showAllVars, setShowAllVars] = useState(false)
+  const [providers, setProviders] = useState<AiProviderOption[]>([])
+
+  useEffect(() => {
+    if (!open) return
+    window.api.terminalModes.list().then((modes: { id: string; label: string; type: string; enabled: boolean }[]) => {
+      setProviders(
+        modes
+          .filter(m => m.enabled && getHeadlessPattern(m.type))
+          .map(m => ({ id: m.id, label: m.label, type: m.type }))
+      )
+    }).catch(() => setProviders([]))
+  }, [open])
 
   useEffect(() => {
     if (automation) {
@@ -99,19 +125,19 @@ export function AutomationDialog({ open, onOpenChange, automation, projectId, ta
       setDescription(automation.description ?? '')
       setTrigger(automation.trigger_config)
       setConditions(automation.conditions)
-      setActions(automation.actions.length > 0 ? automation.actions : [{ type: 'run_command', params: { command: '' } }])
+      setActions(automation.actions.length > 0 ? automation.actions : [{ ...EMPTY_RUN_COMMAND }])
     } else {
       setName('')
       setDescription('')
       setTrigger({ ...EMPTY_TRIGGER })
       setConditions([])
-      setActions([{ type: 'run_command', params: { command: '' } }])
+      setActions([{ ...EMPTY_RUN_COMMAND }])
     }
   }, [automation, open])
 
   const handleSave = () => {
     if (!name.trim()) return
-    const validActions = actions.filter((a: ActionConfig) => (a.params.command as string)?.trim())
+    const validActions = actions.filter(actionIsValid)
     if (validActions.length === 0) return
 
     if (automation) {
@@ -336,26 +362,94 @@ export function AutomationDialog({ open, onOpenChange, automation, projectId, ta
           <div className="rounded-lg border border-border/40 bg-muted/50 p-3 space-y-4">
             <div className="flex items-center justify-between">
               <Label className="text-xs uppercase tracking-wider text-muted-foreground">Then</Label>
-              <Button variant="ghost" size="sm" className="h-6 text-xs" onClick={() => setActions((prev: ActionConfig[]) => [...prev, { type: 'run_command' as const, params: { command: '' } }])}>
-                <Plus className="w-3 h-3 mr-1" /> Add
-              </Button>
+              <div className="flex items-center gap-1">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 text-xs"
+                  onClick={() => setActions((prev: ActionConfig[]) => [...prev, { ...EMPTY_RUN_COMMAND }])}
+                >
+                  <Terminal className="w-3 h-3 mr-1" /> Command
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 text-xs"
+                  disabled={providers.length === 0}
+                  onClick={() => setActions((prev: ActionConfig[]) => [...prev, { type: 'ai', params: { provider: providers[0]?.id ?? '', prompt: '', flags: '' } }])}
+                >
+                  <Sparkles className="w-3 h-3 mr-1" /> AI
+                </Button>
+              </div>
             </div>
 
-            {actions.map((action, i) => (
-              <div key={i} className="flex items-center gap-2">
-                <Textarea
-                  value={(action.params.command as string) ?? ''}
-                  onChange={(e) => setActions((prev: ActionConfig[]) => prev.map((a: ActionConfig, j: number) => j === i ? { ...a, params: { ...a.params, command: e.target.value } } : a))}
-                  placeholder="echo {{task.name}}"
-                  className="font-mono text-xs flex-1 min-h-[60px] resize-y"
-                />
-                {actions.length > 1 && (
-                  <Button variant="ghost" size="sm" className="h-6 w-6 p-0 shrink-0" onClick={() => setActions((prev: ActionConfig[]) => prev.filter((_: ActionConfig, j: number) => j !== i))}>
-                    <Trash2 className="w-3 h-3" />
-                  </Button>
-                )}
-              </div>
-            ))}
+            {actions.map((action, i) => {
+              const updateParam = (key: string, value: string) =>
+                setActions((prev: ActionConfig[]) => prev.map((a: ActionConfig, j: number) => j === i ? { ...a, params: { ...a.params, [key]: value } } : a))
+              const changeType = (newType: ActionType) =>
+                setActions((prev: ActionConfig[]) => prev.map((a: ActionConfig, j: number) => {
+                  if (j !== i) return a
+                  if (newType === a.type) return a
+                  return newType === 'ai'
+                    ? { type: 'ai', params: { provider: providers[0]?.id ?? '', prompt: '', flags: '' } }
+                    : { ...EMPTY_RUN_COMMAND }
+                }))
+
+              return (
+                <div key={i} className="rounded-md border border-border/40 bg-background/40 p-2 space-y-2">
+                  <div className="flex items-center gap-2">
+                    <Select value={action.type} onValueChange={(v) => changeType(v as ActionType)}>
+                      <SelectTrigger size="sm" className="w-32 shrink-0"><SelectValue /></SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="run_command">Run command</SelectItem>
+                        <SelectItem value="ai" disabled={providers.length === 0}>Run AI</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    {action.type === 'ai' && (
+                      <Select
+                        value={(action.params.provider as string) || providers[0]?.id || ''}
+                        onValueChange={(v) => updateParam('provider', v)}
+                      >
+                        <SelectTrigger size="sm" className="flex-1"><SelectValue placeholder="Pick provider" /></SelectTrigger>
+                        <SelectContent>
+                          {providers.map(p => <SelectItem key={p.id} value={p.id}>{p.label}</SelectItem>)}
+                        </SelectContent>
+                      </Select>
+                    )}
+                    <div className="flex-1" />
+                    {actions.length > 1 && (
+                      <Button variant="ghost" size="sm" className="h-6 w-6 p-0 shrink-0" onClick={() => setActions((prev: ActionConfig[]) => prev.filter((_: ActionConfig, j: number) => j !== i))}>
+                        <Trash2 className="w-3 h-3" />
+                      </Button>
+                    )}
+                  </div>
+
+                  {action.type === 'run_command' ? (
+                    <Textarea
+                      value={(action.params.command as string) ?? ''}
+                      onChange={(e) => updateParam('command', e.target.value)}
+                      placeholder="echo {{task.name}}"
+                      className="font-mono text-xs w-full min-h-[60px] resize-y"
+                    />
+                  ) : (
+                    <>
+                      <Textarea
+                        value={(action.params.prompt as string) ?? ''}
+                        onChange={(e) => updateParam('prompt', e.target.value)}
+                        placeholder="Summarize {{task.name}} and post to PR"
+                        className="font-mono text-xs w-full min-h-[60px] resize-y"
+                      />
+                      <Input
+                        value={(action.params.flags as string) ?? ''}
+                        onChange={(e) => updateParam('flags', e.target.value)}
+                        placeholder="extra flags (optional, overrides provider defaults)"
+                        className="font-mono text-[11px] h-7"
+                      />
+                    </>
+                  )}
+                </div>
+              )
+            })}
 
             <table className="w-full text-xs mt-2 border-collapse border border-border/40 rounded">
               <thead>
@@ -381,7 +475,7 @@ export function AutomationDialog({ open, onOpenChange, automation, projectId, ta
 
         <DialogFooter>
           <Button variant="outline" onClick={() => onOpenChange(false)}>Cancel</Button>
-          <Button onClick={handleSave} disabled={!name.trim() || actions.every((a: ActionConfig) => !(a.params.command as string)?.trim())}>
+          <Button onClick={handleSave} disabled={!name.trim() || !actions.some(actionIsValid)}>
             {automation ? 'Save' : 'Create'}
           </Button>
         </DialogFooter>

--- a/packages/domains/automations/src/main/engine.ts
+++ b/packages/domains/automations/src/main/engine.ts
@@ -292,9 +292,16 @@ export class AutomationEngine {
 
       const resolvedPrompt = resolveTemplate(params.prompt, ctx)
       if (!resolvedPrompt.trim()) throw new Error('AI action missing prompt')
-      const resolvedFlags = resolveTemplate(params.flags, ctx)
+      // Flags are NOT template-resolved — they're inserted unquoted into the
+      // shell command, so allowing user-controlled task/project text in there
+      // would be a shell-injection vector. Templates belong in the prompt
+      // (which is shell-quoted).
+      const rawFlags = typeof params.flags === 'string' ? params.flags : undefined
+      if (rawFlags?.includes('{{')) {
+        throw new Error('AI action: template variables are not allowed in flags — put them in the prompt')
+      }
       const command = buildAiHeadlessCommand(
-        { provider: providerId, prompt: resolvedPrompt, flags: resolvedFlags },
+        { provider: providerId, prompt: resolvedPrompt, flags: rawFlags },
         { id: row.id, type: row.type, defaultFlags: row.default_flags },
       )
       if (!command) {

--- a/packages/domains/automations/src/main/engine.ts
+++ b/packages/domains/automations/src/main/engine.ts
@@ -1,14 +1,15 @@
 import type { IpcMain } from 'electron'
 import type { Database } from 'better-sqlite3'
-import type { Automation, AutomationEvent, AutomationRow, AutomationRun } from '@slayzone/automations/shared'
+import type { ActionConfig, Automation, AutomationEvent, AutomationRow, AutomationRun } from '@slayzone/automations/shared'
 import { finishAutomationActionRun, recordActivityEvent, startAutomationActionRun, trimOutputTail } from '@slayzone/history/main'
 import { parseAutomationRow } from '@slayzone/automations/shared'
-import { resolveTemplate, type TemplateContext } from '@slayzone/automations/shared'
+import { buildAiHeadlessCommand, resolveTemplate, type TemplateContext } from '@slayzone/automations/shared'
 import { taskEvents } from '@slayzone/task/main'
 import { exec } from 'child_process'
 
 const MAX_DEPTH = 5
 const ACTION_TIMEOUT_MS = 30_000
+const AI_ACTION_TIMEOUT_MS = 5 * 60_000
 const MAX_RUNS_PER_AUTOMATION = 100
 
 class AutomationCommandError extends Error {
@@ -218,7 +219,7 @@ export class AutomationEngine {
       this.currentDepth = depth + 1
       for (let i = 0; i < automation.actions.length; i++) {
         const action = automation.actions[i]
-        const { command } = this.resolveActionExecution(action.params, ctx)
+        const resolved = this.resolveAction(action, ctx)
         const actionRunId = startAutomationActionRun(this.db, {
           runId,
           automationId: automation.id,
@@ -226,12 +227,12 @@ export class AutomationEngine {
           projectId: event.projectId ?? null,
           actionIndex: i,
           actionType: action.type,
-          command,
+          command: resolved.command,
         })
         const actionStart = Date.now()
 
         try {
-          const result = await this.executeAction(action.params, ctx)
+          const result = await this.runResolvedAction(resolved)
           finishAutomationActionRun(this.db, actionRunId, {
             status: 'success',
             outputTail: result.outputTail,
@@ -277,27 +278,53 @@ export class AutomationEngine {
     this.notifyRenderer()
   }
 
-  private resolveActionExecution(params: Record<string, unknown>, ctx: TemplateContext): { command: string; cwd?: string } {
-    return {
-      command: resolveTemplate(params.command as string, ctx),
-      cwd: params.cwd ? resolveTemplate(params.cwd as string, ctx) : ctx.project?.path,
+  private resolveAction(action: ActionConfig, ctx: TemplateContext): { command: string; cwd?: string; timeoutMs: number } {
+    const params = action.params
+    const cwd = params.cwd ? resolveTemplate(params.cwd as string, ctx) : ctx.project?.path
+
+    if (action.type === 'ai') {
+      const providerId = typeof params.provider === 'string' ? params.provider.trim() : ''
+      if (!providerId) throw new Error('AI action missing provider')
+      const row = this.db.prepare(
+        'SELECT id, type, default_flags FROM terminal_modes WHERE id = ?'
+      ).get(providerId) as { id: string; type: string; default_flags: string | null } | undefined
+      if (!row) throw new Error(`AI action references unknown provider "${providerId}"`)
+
+      const resolvedPrompt = resolveTemplate(params.prompt, ctx)
+      if (!resolvedPrompt.trim()) throw new Error('AI action missing prompt')
+      const resolvedFlags = resolveTemplate(params.flags, ctx)
+      const command = buildAiHeadlessCommand(
+        { provider: providerId, prompt: resolvedPrompt, flags: resolvedFlags },
+        { id: row.id, type: row.type, defaultFlags: row.default_flags },
+      )
+      if (!command) {
+        throw new Error(`AI action: provider type "${row.type}" has no headless command pattern`)
+      }
+      return { command, cwd, timeoutMs: AI_ACTION_TIMEOUT_MS }
     }
+
+    if (action.type === 'run_command') {
+      const command = resolveTemplate(params.command, ctx)
+      if (!command.trim()) throw new Error('run_command action missing command')
+      return { command, cwd, timeoutMs: ACTION_TIMEOUT_MS }
+    }
+
+    throw new Error(`Unknown action type: "${action.type}"`)
   }
 
-  private async executeAction(params: Record<string, unknown>, ctx: TemplateContext): Promise<{ outputTail: string | null }> {
-    const { command, cwd } = this.resolveActionExecution(params, ctx)
-    const result = await this.runCommand(command, cwd)
+  private async runResolvedAction(resolved: { command: string; cwd?: string; timeoutMs: number }): Promise<{ outputTail: string | null }> {
+    const result = await this.runCommand(resolved.command, resolved.cwd, resolved.timeoutMs)
     return { outputTail: trimOutputTail(`${result.stdout}${result.stderr}`) }
   }
 
-  private runCommand(command: string, cwd?: string): Promise<{ stdout: string; stderr: string }> {
+  private runCommand(command: string, cwd: string | undefined, timeoutMs: number): Promise<{ stdout: string; stderr: string }> {
     return new Promise((resolve, reject) => {
-      const child = exec(command, { cwd, timeout: ACTION_TIMEOUT_MS }, (err, stdout, stderr) => {
+      const child = exec(command, { cwd, timeout: timeoutMs }, (err, stdout, stderr) => {
         const outputTail = trimOutputTail(`${stdout}${stderr}`)
         if (err) reject(new AutomationCommandError(`Command failed: ${err.message}\n${stderr}`, outputTail))
         else resolve({ stdout, stderr })
       })
-      setTimeout(() => child.kill(), ACTION_TIMEOUT_MS + 1000)
+      setTimeout(() => child.kill(), timeoutMs + 1000)
     })
   }
 

--- a/packages/domains/automations/src/shared/ai.test.ts
+++ b/packages/domains/automations/src/shared/ai.test.ts
@@ -112,13 +112,27 @@ test('escapes single quote in prompt', () => {
   expect(cmd).toBe(`claude -p 'it'\\''s broken'`)
 })
 
-test('explicit empty flags overrides default', () => {
+test('explicit empty flags overrides default — no flags applied', () => {
   const cmd = buildAiHeadlessCommand(
     { provider: 'claude-code', prompt: 'hi', flags: '' },
     { id: 'claude-code', type: 'claude-code', defaultFlags: '--allow' },
   )
-  // Empty string is treated as "no flags specified" — falls back to default.
-  // Test documents current behaviour: trim('') is falsy, so default applies.
+  expect(cmd).toBe(`claude -p 'hi'`)
+})
+
+test('whitespace-only flags also count as explicit empty', () => {
+  const cmd = buildAiHeadlessCommand(
+    { provider: 'claude-code', prompt: 'hi', flags: '   ' },
+    { id: 'claude-code', type: 'claude-code', defaultFlags: '--allow' },
+  )
+  expect(cmd).toBe(`claude -p 'hi'`)
+})
+
+test('undefined flags falls back to default', () => {
+  const cmd = buildAiHeadlessCommand(
+    { provider: 'claude-code', prompt: 'hi' },
+    { id: 'claude-code', type: 'claude-code', defaultFlags: '--allow' },
+  )
   expect(cmd).toBe(`claude -p 'hi' --allow`)
 })
 

--- a/packages/domains/automations/src/shared/ai.test.ts
+++ b/packages/domains/automations/src/shared/ai.test.ts
@@ -1,0 +1,135 @@
+/**
+ * AI action helper tests
+ * Run with: npx tsx packages/domains/automations/src/shared/ai.test.ts
+ */
+import { buildAiHeadlessCommand, getHeadlessPattern, shellSingleQuote } from './ai.js'
+
+let pass = 0
+let fail = 0
+
+function test(name: string, fn: () => void) {
+  try { fn(); console.log(`  ✓ ${name}`); pass++ }
+  catch (e) { console.log(`  ✗ ${name}`); console.error(`    ${e}`); fail++; process.exitCode = 1 }
+}
+
+function expect(actual: unknown) {
+  return {
+    toBe(expected: unknown) {
+      if (actual !== expected) throw new Error(`Expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+    },
+    toBeNull() {
+      if (actual !== null) throw new Error(`Expected null, got ${JSON.stringify(actual)}`)
+    },
+  }
+}
+
+console.log('\nshellSingleQuote')
+
+test('wraps in single quotes', () => {
+  expect(shellSingleQuote('hello')).toBe(`'hello'`)
+})
+
+test('escapes embedded single quote', () => {
+  // a'b -> 'a'\''b'
+  expect(shellSingleQuote(`a'b`)).toBe(`'a'\\''b'`)
+})
+
+test('escapes multiple single quotes', () => {
+  expect(shellSingleQuote(`it's 'fine'`)).toBe(`'it'\\''s '\\''fine'\\'''`)
+})
+
+test('handles double quotes literally', () => {
+  expect(shellSingleQuote(`say "hi"`)).toBe(`'say "hi"'`)
+})
+
+test('handles backticks literally', () => {
+  expect(shellSingleQuote('`whoami`')).toBe(`'\`whoami\`'`)
+})
+
+test('empty string', () => {
+  expect(shellSingleQuote('')).toBe(`''`)
+})
+
+console.log('\ngetHeadlessPattern')
+
+test('returns pattern for known type', () => {
+  const p = getHeadlessPattern('claude-code')
+  if (!p || !p.includes('{prompt}')) throw new Error(`Bad pattern: ${p}`)
+})
+
+test('returns null for unknown type', () => {
+  expect(getHeadlessPattern('terminal')).toBeNull()
+  expect(getHeadlessPattern('nonexistent')).toBeNull()
+})
+
+console.log('\nbuildAiHeadlessCommand — known providers')
+
+test('claude-code: prompt + flags', () => {
+  const cmd = buildAiHeadlessCommand(
+    { provider: 'claude-code', prompt: 'do thing', flags: '--verbose' },
+    { id: 'claude-code', type: 'claude-code', defaultFlags: '--allow' },
+  )
+  expect(cmd).toBe(`claude -p 'do thing' --verbose`)
+})
+
+test('claude-code: falls back to default flags', () => {
+  const cmd = buildAiHeadlessCommand(
+    { provider: 'claude-code', prompt: 'hello' },
+    { id: 'claude-code', type: 'claude-code', defaultFlags: '--allow-x' },
+  )
+  expect(cmd).toBe(`claude -p 'hello' --allow-x`)
+})
+
+test('claude-code: no flags at all', () => {
+  const cmd = buildAiHeadlessCommand(
+    { provider: 'claude-code', prompt: 'hello' },
+    { id: 'claude-code', type: 'claude-code', defaultFlags: null },
+  )
+  expect(cmd).toBe(`claude -p 'hello'`)
+})
+
+test('codex: prompt comes after flags', () => {
+  const cmd = buildAiHeadlessCommand(
+    { provider: 'codex', prompt: 'fix this', flags: '--full-auto' },
+    { id: 'codex', type: 'codex', defaultFlags: null },
+  )
+  expect(cmd).toBe(`codex exec --full-auto 'fix this'`)
+})
+
+test('gemini -p pattern', () => {
+  const cmd = buildAiHeadlessCommand(
+    { provider: 'gemini', prompt: 'go' },
+    { id: 'gemini', type: 'gemini', defaultFlags: '--yolo' },
+  )
+  expect(cmd).toBe(`gemini -p 'go' --yolo`)
+})
+
+test('escapes single quote in prompt', () => {
+  const cmd = buildAiHeadlessCommand(
+    { provider: 'claude-code', prompt: `it's broken` },
+    { id: 'claude-code', type: 'claude-code', defaultFlags: null },
+  )
+  expect(cmd).toBe(`claude -p 'it'\\''s broken'`)
+})
+
+test('explicit empty flags overrides default', () => {
+  const cmd = buildAiHeadlessCommand(
+    { provider: 'claude-code', prompt: 'hi', flags: '' },
+    { id: 'claude-code', type: 'claude-code', defaultFlags: '--allow' },
+  )
+  // Empty string is treated as "no flags specified" — falls back to default.
+  // Test documents current behaviour: trim('') is falsy, so default applies.
+  expect(cmd).toBe(`claude -p 'hi' --allow`)
+})
+
+console.log('\nbuildAiHeadlessCommand — unknown provider type')
+
+test('unknown type returns null', () => {
+  const cmd = buildAiHeadlessCommand(
+    { provider: 'custom', prompt: 'hi' },
+    { id: 'custom', type: 'terminal', defaultFlags: null },
+  )
+  expect(cmd).toBeNull()
+})
+
+console.log(`\n${pass} passed, ${fail} failed`)

--- a/packages/domains/automations/src/shared/ai.test.ts
+++ b/packages/domains/automations/src/shared/ai.test.ts
@@ -104,6 +104,24 @@ test('gemini -p pattern', () => {
   expect(cmd).toBe(`gemini -p 'go' --yolo`)
 })
 
+test('literal {flags} in prompt does not corrupt flags placeholder', () => {
+  const cmd = buildAiHeadlessCommand(
+    { provider: 'claude-code', prompt: 'use {flags} here', flags: '--verbose' },
+    { id: 'claude-code', type: 'claude-code', defaultFlags: null },
+  )
+  // Prompt stays literal (still inside single quotes), flags placeholder
+  // gets the actual flags — not the prompt's text.
+  expect(cmd).toBe(`claude -p 'use {flags} here' --verbose`)
+})
+
+test('literal {prompt} in flags does not break substitution', () => {
+  const cmd = buildAiHeadlessCommand(
+    { provider: 'claude-code', prompt: 'hi', flags: '--note={prompt}' },
+    { id: 'claude-code', type: 'claude-code', defaultFlags: null },
+  )
+  expect(cmd).toBe(`claude -p 'hi' --note={prompt}`)
+})
+
 test('escapes single quote in prompt', () => {
   const cmd = buildAiHeadlessCommand(
     { provider: 'claude-code', prompt: `it's broken` },

--- a/packages/domains/automations/src/shared/ai.ts
+++ b/packages/domains/automations/src/shared/ai.ts
@@ -46,10 +46,11 @@ export function buildAiHeadlessCommand(
 ): string | null {
   const pattern = HEADLESS_PATTERNS[provider.type]
   if (!pattern) return null
-  // Empty/whitespace-only flags fall back to the provider's default — the
-  // dialog stores `flags: ''` for newly-added AI actions, so treating empty
-  // as "use default" matches user expectations.
-  const flags = (params.flags?.trim() || provider.defaultFlags?.trim() || '')
+  // Only `undefined` falls back to the provider's defaults. An explicit empty
+  // string means "no flags" — the dialog seeds new actions with the provider's
+  // defaultFlags so users see what's running, and clearing the field is the
+  // signal to opt out of defaults.
+  const flags = (params.flags ?? provider.defaultFlags ?? '').trim()
   return pattern
     .replace('{prompt}', shellSingleQuote(params.prompt))
     .replace('{flags}', flags)

--- a/packages/domains/automations/src/shared/ai.ts
+++ b/packages/domains/automations/src/shared/ai.ts
@@ -51,9 +51,14 @@ export function buildAiHeadlessCommand(
   // defaultFlags so users see what's running, and clearing the field is the
   // signal to opt out of defaults.
   const flags = (params.flags ?? provider.defaultFlags ?? '').trim()
+  // Single-pass substitution — sequential .replace would let prompt content
+  // containing the literal text "{flags}" corrupt the second placeholder.
+  const replacements: Record<string, string> = {
+    '{prompt}': shellSingleQuote(params.prompt),
+    '{flags}': flags,
+  }
   return pattern
-    .replace('{prompt}', shellSingleQuote(params.prompt))
-    .replace('{flags}', flags)
+    .replace(/\{prompt\}|\{flags\}/g, (m) => replacements[m])
     .replace(/\s+/g, ' ')
     .trim()
 }

--- a/packages/domains/automations/src/shared/ai.ts
+++ b/packages/domains/automations/src/shared/ai.ts
@@ -1,0 +1,58 @@
+import type { AiActionParams } from './types'
+
+/**
+ * Headless command pattern for each known provider type.
+ *
+ * `{prompt}` is replaced with a single-quote-escaped prompt. `{flags}` is
+ * replaced with raw flags (or empty string). Patterns target one-shot,
+ * non-interactive invocations of each provider's CLI.
+ */
+const HEADLESS_PATTERNS: Record<string, string> = {
+  'claude-code': "claude -p {prompt} {flags}",
+  'codex': "codex exec {flags} {prompt}",
+  'gemini': "gemini -p {prompt} {flags}",
+  'cursor-agent': "cursor-agent -p {prompt} {flags}",
+  'opencode': "opencode run {flags} {prompt}",
+  'qwen-code': "qwen -p {prompt} {flags}",
+  'copilot': "copilot -p {prompt} {flags}",
+}
+
+export interface ProviderInfo {
+  id: string
+  type: string
+  defaultFlags?: string | null
+}
+
+/**
+ * Single-quote escape for POSIX shell. Wraps the value in single quotes and
+ * escapes any embedded single quote by closing, escaping, reopening: a'b -> 'a'\''b'
+ */
+export function shellSingleQuote(value: unknown): string {
+  const s = typeof value === 'string' ? value : value == null ? '' : String(value)
+  return `'${s.replace(/'/g, `'\\''`)}'`
+}
+
+export function getHeadlessPattern(providerType: string): string | null {
+  return HEADLESS_PATTERNS[providerType] ?? null
+}
+
+/**
+ * Build the headless CLI command for an AI action. Returns null if the
+ * provider type has no known headless pattern (e.g. plain `terminal`).
+ */
+export function buildAiHeadlessCommand(
+  params: AiActionParams,
+  provider: ProviderInfo,
+): string | null {
+  const pattern = HEADLESS_PATTERNS[provider.type]
+  if (!pattern) return null
+  // Empty/whitespace-only flags fall back to the provider's default — the
+  // dialog stores `flags: ''` for newly-added AI actions, so treating empty
+  // as "use default" matches user expectations.
+  const flags = (params.flags?.trim() || provider.defaultFlags?.trim() || '')
+  return pattern
+    .replace('{prompt}', shellSingleQuote(params.prompt))
+    .replace('{flags}', flags)
+    .replace(/\s+/g, ' ')
+    .trim()
+}

--- a/packages/domains/automations/src/shared/index.ts
+++ b/packages/domains/automations/src/shared/index.ts
@@ -1,2 +1,3 @@
 export * from './types'
 export * from './templates'
+export * from './ai'

--- a/packages/domains/automations/src/shared/templates.ts
+++ b/packages/domains/automations/src/shared/templates.ts
@@ -20,7 +20,8 @@ export interface TemplateContext {
   }
 }
 
-export function resolveTemplate(template: string, ctx: TemplateContext): string {
+export function resolveTemplate(template: unknown, ctx: TemplateContext): string {
+  if (typeof template !== 'string') return ''
   return template.replace(/\{\{(\w+)\.(\w+)\}\}/g, (_match, group: string, key: string) => {
     const obj = ctx[group as keyof TemplateContext]
     if (!obj || typeof obj !== 'object') return ''

--- a/packages/domains/automations/src/shared/types.ts
+++ b/packages/domains/automations/src/shared/types.ts
@@ -24,11 +24,29 @@ export interface ConditionConfig {
 
 // -- Action --
 
-export type ActionType = 'run_command'
+export type ActionType = 'run_command' | 'ai'
 
 export interface ActionConfig {
   type: ActionType
   params: Record<string, unknown>
+}
+
+export interface RunCommandActionParams {
+  command: string
+  cwd?: string
+}
+
+/**
+ * AI action — run a configured AI provider in headless mode with a prompt.
+ *
+ * `provider` is a terminal mode id (e.g. 'claude-code', 'codex'). The engine
+ * derives the non-interactive shell invocation from the provider's type.
+ */
+export interface AiActionParams {
+  provider: string
+  prompt: string
+  flags?: string
+  cwd?: string
 }
 
 // -- Automation --


### PR DESCRIPTION
Automations can now run a configured AI provider (Claude Code, Codex, Gemini, Cursor, OpenCode, Qwen, Copilot) in headless mode with a templated prompt, in addition to shell commands.

- New 'ai' action type with provider/prompt/flags params
- Engine dispatches by action type, looks up provider from terminal_modes, builds non-interactive CLI invocation per provider type
- AI actions get a 5-minute timeout vs 30s for shell commands
- Dialog gets per-action type selector with provider dropdown for AI
- Harden resolveTemplate + shellSingleQuote against non-string input; engine now throws clear errors for missing prompt/command/unknown type instead of cryptic TypeError

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces an `ai` action type for automations, allowing configured AI providers (Claude Code, Codex, Gemini, etc.) to run in headless mode with a templated prompt alongside the existing `run_command` type. The engine dispatches by action type, builds a per-provider CLI invocation via a single-pass regex substitution, and applies a 5-minute timeout for AI actions.

The security measures around shell injection are notably solid: flags are never template-resolved, the `{{` guard blocks template variables from reaching the flags field at both the client and engine layers, the prompt is always single-quote-escaped via `shellSingleQuote`, and `??` (not `||`) correctly lets an explicit empty flags string opt out of provider `defaultFlags`.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; no new P0/P1 bugs found, and prior shell-injection and empty-flags concerns appear addressed.

No new critical or high-severity bugs found in the current diff. The single-pass regex substitution, the {{ guard, the ?? fallback, and the providerMissing dialog warning all directly address the issues raised in earlier review threads. Score is 4 rather than 5 as a conservative acknowledgement of the inherent complexity of a feature that builds and executes shell commands from user-configured data.

engine.ts deserves the most scrutiny — it is the execution boundary where shell commands are built and run.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/domains/automations/src/shared/ai.ts | New file providing shellSingleQuote, getHeadlessPattern, and buildAiHeadlessCommand; uses single-pass regex substitution to avoid prompt-content-corrupts-flags-placeholder; correctly uses ?? to distinguish undefined (fall back to defaultFlags) from '' (explicit no-flags) |
| packages/domains/automations/src/main/engine.ts | resolveAction dispatches on action.type with clear errors; flags are not template-resolved and guarded against {{ injection; AI actions get 5-min timeout |
| packages/domains/automations/src/client/AutomationDialog.tsx | Dialog adds per-action type selector, AI provider dropdown, providerMissing warning, and client-side {{ guard mirroring the engine; providers fetched fresh on each dialog open; actionIsValid correctly gates Save button |
| packages/domains/automations/src/shared/templates.ts | resolveTemplate hardened to accept unknown and return '' for non-string input, preventing TypeError on missing/null params |
| packages/domains/automations/src/shared/types.ts | Adds ActionType 'ai', AiActionParams, and RunCommandActionParams interfaces; clean, no issues |
| packages/domains/automations/src/shared/ai.test.ts | Thorough test coverage for shellSingleQuote, getHeadlessPattern, and buildAiHeadlessCommand including edge cases (empty flags vs undefined, {flags} in prompt, single-quote escaping) |
| packages/domains/automations/src/shared/index.ts | Adds ai.ts re-export; no issues |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant U as User (Dialog)
    participant D as AutomationDialog
    participant E as AutomationEngine
    participant DB as SQLite terminal_modes
    participant SH as exec shell

    U->>D: Click AI button
    D->>D: terminalModes.list() - filter enabled + headless providers
    D-->>U: Provider dropdown + prompt/flags inputs

    U->>D: Fill provider, prompt, flags then Save
    D->>D: actionIsValid() - check provider, prompt, no template in flags
    D->>E: onSave(automation with ai action)

    note over E: On trigger fire
    E->>DB: SELECT id, type, default_flags WHERE id = providerId
    DB-->>E: row or undefined throws error

    E->>E: resolveTemplate(params.prompt, ctx)
    E->>E: rawFlags guard against template variables
    E->>E: buildAiHeadlessCommand(params, provider)
    note over E: Single-pass regex replaces prompt and flags placeholders

    E->>SH: exec(command, cwd, timeout 5min)
    SH-->>E: stdout and stderr
    E->>DB: finishAutomationActionRun success or error
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(automations): single-pass placeholde..."](https://github.com/debuglebowski/slayzone/commit/e7f8fad22694ff07e3e486ac984da476b820c77c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30089998)</sub>

<!-- /greptile_comment -->