### PR TITLE
Fix GUI subprocess PATH

### DIFF
--- a/packages/domains/terminal/src/main/shell-env.ts
+++ b/packages/domains/terminal/src/main/shell-env.ts
@@ -39,10 +39,21 @@ export {
  * (chat-handlers) so subprocess Bash tools find the same binaries the user has.
  */
 let cachedEnrichedPath: string | null | undefined
+const PATH_OUTPUT_MARKER = '__SLAYZONE_PATH__'
+
 export function getEnrichedPath(): string | null {
   if (cachedEnrichedPath !== undefined) return cachedEnrichedPath
   cachedEnrichedPath = resolveEnrichedPath()
   return cachedEnrichedPath
+}
+
+function extractPathProbeOutput(output: string): string | null {
+  for (const line of output.split(/\r?\n/).reverse()) {
+    if (!line.startsWith(PATH_OUTPUT_MARKER)) continue
+    const value = line.slice(PATH_OUTPUT_MARKER.length).trim()
+    return value || null
+  }
+  return null
 }
 
 function resolveEnrichedPath(): string | null {
@@ -51,16 +62,20 @@ function resolveEnrichedPath(): string | null {
   // Fish: $PATH is a list — `echo $PATH` prints space-separated, invalid as OS PATH.
   // `string join ":" $PATH` produces colon-joined.
   const isFish = shell.endsWith('/fish')
-  const cmd = isFish ? 'string join ":" $PATH' : 'echo $PATH'
+  const cmd = isFish
+    ? `printf "\\n${PATH_OUTPUT_MARKER}%s\\n" (string join ":" $PATH)`
+    : `printf '\\n${PATH_OUTPUT_MARKER}%s\\n' "$PATH"`
 
   // Interactive login shell first — sources .zshrc/.bashrc where pnpm/nvm add PATH
   try {
     const args = getShellStartupArgs(shell)
     const result = execFileSync(shell, [...args, '-c', cmd], {
       timeout: 5000,
-      encoding: 'utf-8'
-    }).trim()
-    if (result) return result
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore']
+    })
+    const pathValue = extractPathProbeOutput(result)
+    if (pathValue) return pathValue
   } catch {
     /* fall through */
   }
@@ -69,9 +84,11 @@ function resolveEnrichedPath(): string | null {
   try {
     const result = execFileSync(shell, ['-l', '-c', cmd], {
       timeout: 5000,
-      encoding: 'utf-8'
-    }).trim()
-    if (result) return result
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore']
+    })
+    const pathValue = extractPathProbeOutput(result)
+    if (pathValue) return pathValue
   } catch {
     /* fall through */
   }
@@ -152,10 +169,14 @@ export async function whichBinary(name: string): Promise<string | null> {
   }
 
   try {
-    const shell = resolveUserShell()
-    const shellArgs = getShellStartupArgs(shell)
+    const env = { ...process.env }
+    const enrichedPath = getEnrichedPath()
+    if (enrichedPath) env.PATH = enrichedPath
     const checkCmd = `command -v ${quoteForShell(name)}`
-    const { stdout } = await execFileAsync(shell, [...shellArgs, '-c', checkCmd], { timeout: 3000 })
+    const { stdout } = await execFileAsync('/bin/sh', ['-c', checkCmd], {
+      timeout: 3000,
+      env
+    })
     const found = stdout.trim().split('\n')[0]
     return found || null
   } catch {

--- a/packages/domains/worktrees/src/main/exec-async.ts
+++ b/packages/domains/worktrees/src/main/exec-async.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'child_process'
 import { recordDiagnosticEvent } from '@slayzone/diagnostics/main'
+import { getEnrichedPath } from '@slayzone/terminal/main'
 import type { DiagnosticSource } from '@slayzone/diagnostics/shared'
 
 export function trimOutput(value: unknown, maxLength = 1200): string | null {
@@ -16,6 +17,13 @@ export interface ExecResult {
   status: number | null
 }
 
+function subprocessEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env }
+  const enrichedPath = getEnrichedPath()
+  if (enrichedPath) env.PATH = enrichedPath
+  return env
+}
+
 /** Async subprocess execution — won't block the main process. */
 export function execAsync(
   command: string,
@@ -28,6 +36,7 @@ export function execAsync(
     const startedAt = Date.now()
     const child = spawn(command, args, {
       cwd: opts.cwd,
+      env: subprocessEnv(),
       stdio: ['pipe', 'pipe', 'pipe']
     })
     const stdout: string[] = []

--- a/packages/domains/worktrees/src/main/gh-cli.ts
+++ b/packages/domains/worktrees/src/main/gh-cli.ts
@@ -1,4 +1,4 @@
-import { whichBinary, resolveUserShell, getShellStartupArgs } from '@slayzone/terminal/main'
+import { whichBinary } from '@slayzone/terminal/main'
 import type {
   GhPullRequest,
   GhPrComment,
@@ -22,16 +22,12 @@ async function resolveGhPath(): Promise<string | null> {
   return ghPath
 }
 
-/** Run gh with the user's shell environment so PATH is correct. */
+/** Run gh directly so shell startup output cannot corrupt JSON stdout. */
 async function spawnGh(args: string[], opts: { cwd?: string; timeout?: number } = {}) {
-  if (!ghPath) await resolveGhPath()
-  if (!ghPath) throw new Error('gh CLI not found')
+  const resolvedGhPath = await resolveGhPath()
+  if (!resolvedGhPath) throw new Error('gh CLI not found')
 
-  const shell = resolveUserShell()
-  const shellArgs = getShellStartupArgs(shell)
-  const cmd = [ghPath, ...args].map((a) => `'${a.replace(/'/g, `'"'"'`)}'`).join(' ')
-
-  return execAsync(shell, [...shellArgs, '-c', cmd], { ...opts, source: 'gh' })
+  return execAsync(resolvedGhPath, args, { ...opts, source: 'gh' })
 }
 
 interface RawGhPr {

--- a/packages/shared/platform/src/cli-install.ts
+++ b/packages/shared/platform/src/cli-install.ts
@@ -15,24 +15,29 @@ export interface CliInstallResult {
   pathNotInPATH?: boolean
 }
 
+function platformPath() {
+  return process.platform === 'win32' ? path.win32 : path.posix
+}
+
 export function getCliBinDir(): string {
+  const pathForPlatform = platformPath()
   switch (process.platform) {
     case 'darwin':
       return '/usr/local/bin'
     case 'win32':
-      return path.join(
-        process.env.LOCALAPPDATA ?? path.join(os.homedir(), 'AppData', 'Local'),
+      return pathForPlatform.join(
+        process.env.LOCALAPPDATA ?? pathForPlatform.join(os.homedir(), 'AppData', 'Local'),
         'SlayZone',
         'bin'
       )
     default:
-      return path.join(os.homedir(), '.local', 'bin')
+      return pathForPlatform.join(os.homedir(), '.local', 'bin')
   }
 }
 
 export function getCliBinTarget(): string {
   const name = process.platform === 'win32' ? 'slay.cmd' : 'slay'
-  return path.join(getCliBinDir(), name)
+  return platformPath().join(getCliBinDir(), name)
 }
 
 export function checkCliInstalled(): { installed: boolean; path?: string } {
@@ -142,8 +147,8 @@ function installWindows(cliSrcPath: string, binDir: string, target: string): Cli
   }
   // Copy slay.js next to the .cmd shim
   // TODO: In dev mode, slay.js is at ../cli/dist/slay.js, not ../cli/bin/slay.js — shim won't work in dev on Windows
-  const srcJs = cliSrcPath.replace(/[/\\]slay$/, path.sep + 'slay.js')
-  const destJs = path.join(binDir, 'slay.js')
+  const srcJs = cliSrcPath.replace(/([/\\])slay$/, '$1slay.js')
+  const destJs = path.win32.join(binDir, 'slay.js')
   if (fs.existsSync(srcJs)) {
     fs.copyFileSync(srcJs, destJs)
   } else {

--- a/packages/shared/platform/src/migrations.test.ts
+++ b/packages/shared/platform/src/migrations.test.ts
@@ -118,6 +118,9 @@ describe('migrateStateDir', () => {
   // --- Failure / rollback ---
 
   test('fails and rolls back when newDir parent is not writable', () => {
+    if (process.platform === 'win32') {
+      return // Windows chmod does not make the directory unwritable for this test.
+    }
     if (process.getuid?.() === 0) {
       return // skip when running as root
     }


### PR DESCRIPTION
Fixes GUI-launched Git/GitHub commands missing user PATH.

SlayZone was spawning Git worktree operations directly from Electron PATH and running gh through interactive zsh. That broke Git LFS hooks when Homebrew was missing from PATH, and let zsh prompt/gitstatus noise make gh PR listing fail.

This moves enriched PATH into the shared platform shell helper, applies it to worktree subprocesses and setup scripts, and runs gh directly with that environment so shell startup files cannot contaminate stderr.

Validation:
- @slayzone/platform tests
- @slayzone/worktrees typecheck
- @slayzone/terminal typecheck
- @slayzone/app typecheck
- stripped-PATH smoke for git-lfs and gh pr list
- macOS arm64 app build + codesign verify

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes GUI-launched subprocess PATH handling for Git and GitHub CLI workflows. The main changes are:

- Adds marker-based PATH probing for noisy shell startup output.
- Applies the enriched PATH to worktree subprocess execution.
- Runs `gh` directly through the resolved binary path instead of through the interactive shell.
- Uses platform-specific path helpers for CLI install paths.
- Skips an unwritable-directory migration test on Windows.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/domains/terminal/src/main/shell-env.ts | Adds marker-filtered PATH extraction and resolves binaries using enriched environment state. |
| packages/domains/worktrees/src/main/exec-async.ts | Injects the enriched PATH into worktree subprocesses. |
| packages/domains/worktrees/src/main/gh-cli.ts | Runs the resolved `gh` binary directly to avoid shell startup output corrupting command results. |
| packages/shared/platform/src/cli-install.ts | Uses platform-specific path joins for CLI install target and Windows shim copy paths. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(platform): pass Windows platform tes..."](https://github.com/debuglebowski/slayzone/commit/a5483d5a54e209fe14f753e2698fde3bbfca31ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34551453)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/slayzone/github/debuglebowski/slayzone/-/custom-context?memory=4d0a5da1-ee49-442f-ba49-d4a3dc97238d))
- Context used - AGENTS.md ([source](https://app.greptile.com/slayzone/github/debuglebowski/slayzone/-/custom-context?memory=ab121f38-2559-4d9f-973d-c13f20b07978))

<!-- /greptile_comment -->