### PR TITLE
Speed up task open paths

### DIFF
--- a/packages/apps/app/e2e/perf/scenarios.spec.ts
+++ b/packages/apps/app/e2e/perf/scenarios.spec.ts
@@ -32,6 +32,7 @@ void __dirname
 const ITERATIONS = 5
 const RUN_DIR = path.join(defaultResultsDir(), `run-${Date.now()}`)
 const PROJ_ABBREV = 'PE'
+const PROJECT_NAME = 'PerfRun'
 
 let projectId: string
 let firstTaskId: string
@@ -46,7 +47,7 @@ test.describe
       await resetApp(mainWindow)
       const s = seed(mainWindow)
       const p = await s.createProject({
-        name: 'PerfRun',
+        name: PROJECT_NAME,
         color: '#8b5cf6',
         path: TEST_PROJECT_PATH
       })
@@ -159,6 +160,101 @@ test.describe
               { timeout: 5000 }
             )
             .catch(() => {})
+        }
+      }
+      const result = await profileScenario(mainWindow, definition, { runDir: RUN_DIR })
+      console.log(
+        `[perf] ${result.name} p50=${result.summary.wallP50}ms p95=${result.summary.wallP95}ms`
+      )
+      expect(result.runs.length).toBe(ITERATIONS)
+    })
+
+    test('open-closed-task-from-sidebar', async ({ mainWindow }) => {
+      const taskId = secondTaskId
+
+      const definition: ScenarioDefinition = {
+        name: 'open-closed-task-from-sidebar',
+        description: 'Click a closed task row in the sidebar tree, wait for task detail mount.',
+        iterations: ITERATIONS,
+        beforeEach: async (page) => {
+          await page.evaluate(
+            ({ anchorId, targetId, pid }) => {
+              const storeApi = (window as any).__slayzone_tabStore
+              const store = storeApi.getState()
+              storeApi.setState({
+                sidebarView: 'projects',
+                selectedProjectId: pid,
+                treeStatusFilter: ['in_progress'],
+                treePriorityFilter: [1, 2, 3, 4, 5],
+                treeShowSubtasks: true,
+                treeShowAllSubtasks: false,
+                treeShowOnlyActive: false,
+                treeShowTemporary: true,
+                treeShowAllOpen: true,
+                treeCrossOutDone: false,
+                treeShowStatus: false,
+                treeShowPriority: true,
+                treeShowWorktree: true,
+                treeGroupBy: 'status',
+                treeOrderBy: 'manual',
+                treeOrderDir: 'asc'
+              })
+              store.openTaskInBackground(anchorId)
+              store.closeTabByTaskId(targetId)
+              store.setActiveTabIndex(0)
+              storeApi.setState({ sidebarView: 'tree' })
+            },
+            { anchorId: firstTaskId, targetId: taskId, pid: projectId }
+          )
+          const expand = page.getByRole('button', { name: `Expand ${PROJECT_NAME}` }).first()
+          if (await expand.isVisible({ timeout: 500 }).catch(() => false)) {
+            await expand.click({ force: true }).catch(() => {})
+          }
+          await page.evaluate((id) => {
+            const store = (window as any).__slayzone_tabStore.getState()
+            performance.clearMarks(`sz:taskDetail:${id}:mount`)
+            store.closeTabByTaskId(id)
+            store.setActiveTabIndex(0)
+          }, taskId)
+          const row = page.locator(
+            `[data-sidebar-tree-item="task"][data-task-id="${taskId}"]`
+          )
+          await expect(row).toBeVisible({ timeout: 5000 })
+          await page.waitForTimeout(150)
+        },
+        run: async (page) => {
+          await page.evaluate(async (id) => {
+            const mark = `sz:taskDetail:${id}:mount`
+            performance.clearMarks(mark)
+            const row = document.querySelector(
+              `[data-sidebar-tree-item="task"][data-task-id="${id}"]`
+            ) as HTMLButtonElement | null
+            if (!row) throw new Error(`task row missing: ${id}`)
+            row.click()
+            await new Promise<void>((resolve, reject) => {
+              const deadline = performance.now() + 5000
+              const tick = () => {
+                if (performance.getEntriesByName(mark, 'mark').length > 0) {
+                  resolve()
+                  return
+                }
+                if (performance.now() > deadline) {
+                  reject(new Error(`task detail mount timeout: ${id}`))
+                  return
+                }
+                window.setTimeout(tick, 5)
+              }
+              tick()
+            })
+          }, taskId)
+        },
+        afterEach: async (page) => {
+          await page.evaluate((id) => {
+            const store = (window as any).__slayzone_tabStore.getState()
+            store.closeTabByTaskId(id)
+            store.setActiveTabIndex(0)
+          }, taskId)
+          await page.waitForTimeout(100)
         }
       }
       const result = await profileScenario(mainWindow, definition, { runDir: RUN_DIR })

--- a/packages/apps/app/src/renderer/src/App.tsx
+++ b/packages/apps/app/src/renderer/src/App.tsx
@@ -151,6 +151,10 @@ import { BoostPill } from '@/components/usage/BoostPill'
 import { useUsage } from '@/components/usage/useUsage'
 import { useOnboardingChecklist } from '@/hooks/useOnboardingChecklist'
 import { TaskShell } from '@slayzone/task/client/TaskShell'
+import {
+  buildTaskDetailDataFromSnapshot,
+  taskDetailCache
+} from '@slayzone/task/client/taskDetailCache'
 // Extracted hooks (self-contained, clean interfaces)
 import { useHomePanel, HOME_PANEL_SIZE_KEY } from '@/hooks/useHomePanel'
 import { useTerminalStateTracking } from '@/hooks/useTerminalStateTracking'
@@ -159,11 +163,11 @@ import { useTabColors } from '@/hooks/useTabColors'
 import { useVisibleTabs } from '@/hooks/useVisibleTabs'
 import { useDiagnosticsSync } from '@/hooks/useDiagnosticsSync'
 // Lazy-loaded: heavy components not needed for first paint
-const TaskDetailDataLoader = lazy(() =>
+const loadTaskDetailDataLoader = () =>
   import('@slayzone/task/client/TaskDetailDataLoader').then((m) => ({
     default: m.TaskDetailDataLoader
   }))
-)
+const TaskDetailDataLoader = lazy(loadTaskDetailDataLoader)
 const FileEditorView = lazy(() =>
   import('@slayzone/file-editor/client/FileEditorView').then((m) => ({ default: m.FileEditorView }))
 )
@@ -651,9 +655,34 @@ function App(): React.JSX.Element {
     return m
   }, [allIdleTasks])
 
+  const tasksMap = useMemo(() => new Map(tasks.map((t) => [t.id, t])), [tasks])
+  const projectsMap = useMemo(() => new Map(projects.map((p) => [p.id, p])), [projects])
   const selectedProject = useMemo(
-    () => projects.find((p) => p.id === selectedProjectId) ?? null,
-    [projects, selectedProjectId]
+    () => projectsMap.get(selectedProjectId) ?? null,
+    [projectsMap, selectedProjectId]
+  )
+  const prefetchTaskDetail = useCallback(
+    (taskId: string) => {
+      const task = tasksMap.get(taskId)
+      if (task) {
+        taskDetailCache.prime(
+          'taskDetail',
+          [taskId],
+          buildTaskDetailDataFromSnapshot({
+            task,
+            tasks,
+            projects,
+            tags,
+            taskTagIds: taskTags.get(taskId) ?? [],
+            projectPathMissing: task.project_id === selectedProjectId ? projectPathMissing : false
+          })
+        )
+      } else {
+        taskDetailCache.prefetch('taskDetail', taskId)
+      }
+      void loadTaskDetailDataLoader()
+    },
+    [tasksMap, tasks, projects, tags, taskTags, selectedProjectId, projectPathMissing]
   )
 
   // Project lock guard — single chokepoint for task-open paths. Resolves the task's
@@ -672,8 +701,8 @@ function App(): React.JSX.Element {
       const taskProject =
         projectOverride ??
         (() => {
-          const task = tasks.find((t) => t.id === taskId)
-          return task ? projects.find((p) => p.id === task.project_id) : undefined
+          const task = tasksMap.get(taskId)
+          return task ? projectsMap.get(task.project_id) : undefined
         })()
       if (taskProject && isProjectLocked(taskProject)) {
         toast(PROJECT_LOCKED_TOAST)
@@ -684,9 +713,10 @@ function App(): React.JSX.Element {
         return
       }
       if (taskProject) recordTaskOpen(taskProject.id)
+      prefetchTaskDetail(taskId)
       fn(taskId)
     },
-    [tasks, projects]
+    [tasksMap, projectsMap, prefetchTaskDetail]
   )
 
   const openTask = useCallback(
@@ -725,9 +755,6 @@ function App(): React.JSX.Element {
     if (!selectedProjectId || !projects.some((p) => p.id === selectedProjectId))
       setSelectedProjectId(projects[0].id)
   }, [projects, selectedProjectId, setSelectedProjectId])
-
-  // Task lookup map (used for tab props and active-tab project switching)
-  const tasksMap = useMemo(() => new Map(tasks.map((t) => [t.id, t])), [tasks])
 
   // Visible tabs (project-scoped filtering — purely visual, full tabs stay mounted)
   const { visibleTabs, visibleActiveIndex, toFullIndex, toVisibleIndex } = useVisibleTabs(
@@ -870,14 +897,18 @@ function App(): React.JSX.Element {
   }, [selectedProjectId, projects, validateProjectPath])
 
   // Computed values
-  const projectTasks = selectedProjectId
-    ? tasks.filter((t) => t.project_id === selectedProjectId)
-    : []
-  const projectTags = selectedProjectId
-    ? tags.filter((t) => t.project_id === selectedProjectId)
-    : tags
-  const displayTasks = applyFilters(projectTasks, filter, taskTags, selectedProject?.columns_config)
-  const projectsMap = new Map(projects.map((p) => [p.id, p]))
+  const projectTasks = useMemo(
+    () => (selectedProjectId ? tasks.filter((t) => t.project_id === selectedProjectId) : []),
+    [tasks, selectedProjectId]
+  )
+  const projectTags = useMemo(
+    () => (selectedProjectId ? tags.filter((t) => t.project_id === selectedProjectId) : tags),
+    [tags, selectedProjectId]
+  )
+  const displayTasks = useMemo(
+    () => applyFilters(projectTasks, filter, taskTags, selectedProject?.columns_config),
+    [projectTasks, filter, taskTags, selectedProject?.columns_config]
+  )
   const createTaskDialogDraft = useMemo(
     () => ({ projectId: selectedProjectId || projects[0]?.id, ...createTaskDraft }),
     [selectedProjectId, projects, createTaskDraft]
@@ -2201,6 +2232,7 @@ function App(): React.JSX.Element {
               useTabStore.getState().setActiveView('usage-analytics')
             }}
             onTaskClick={openTask}
+            onTaskPrefetch={prefetchTaskDetail}
             onCloseTab={closeTabByTaskId}
             onOpenTaskInBackground={(id) => useTabStore.getState().openTaskInBackground(id)}
             onCreateTemporaryTask={(projectId) => {
@@ -2257,9 +2289,7 @@ function App(): React.JSX.Element {
                 }
                 isPinned={!!task.pinned}
                 onTogglePin={() => setTaskPinned(task.id, !task.pinned)}
-                canMarkUnread={
-                  terminalStates.get(task.id) === 'idle' && !task.needs_attention
-                }
+                canMarkUnread={terminalStates.get(task.id) === 'idle' && !task.needs_attention}
               >
                 {child}
               </TaskContextMenu>
@@ -2997,6 +3027,7 @@ function App(): React.JSX.Element {
                 onCreatedAndOpen={handleTaskCreatedAndOpen}
                 draft={createTaskDialogDraft}
                 tags={projectTags}
+                projects={projects}
                 onTagCreated={(tag: Tag) => setTags((prev) => [...prev, tag])}
               />
             </Suspense>

--- a/packages/apps/app/src/renderer/src/components/sidebar/AppSidebar.tsx
+++ b/packages/apps/app/src/renderer/src/components/sidebar/AppSidebar.tsx
@@ -29,6 +29,7 @@ interface AppSidebarProps {
   onUsageAnalytics: () => void
   onLeaderboard: () => void
   onTaskClick?: (taskId: string) => void
+  onTaskPrefetch?: (taskId: string) => void
   onCloseTab?: (taskId: string) => void
   onOpenTaskInBackground?: (taskId: string) => void
   onCreateTemporaryTask?: (projectId: string) => void
@@ -132,6 +133,7 @@ export function AppSidebar({
   onUsageAnalytics,
   onLeaderboard,
   onTaskClick,
+  onTaskPrefetch,
   onCloseTab,
   onOpenTaskInBackground,
   onCreateTemporaryTask,
@@ -228,6 +230,7 @@ export function AppSidebar({
               onSelectProject,
               onProjectSettings,
               onTaskClick,
+              onTaskPrefetch,
               onCloseTab,
               onOpenTaskInBackground,
               onCreateTemporaryTask,

--- a/packages/apps/app/src/renderer/src/components/sidebar/views/TreeView.tsx
+++ b/packages/apps/app/src/renderer/src/components/sidebar/views/TreeView.tsx
@@ -177,6 +177,7 @@ interface TaskBranchCtx {
   treeGroupBy: 'none' | 'status' | 'priority'
   treeGroupPinned: boolean
   onTaskClick?: (taskId: string) => void
+  onTaskPrefetch?: (taskId: string) => void
   onRowSelectClick: (event: ReactMouseEvent<HTMLButtonElement>, taskId: string) => void
   onCloseTab?: (taskId: string) => void
   onOpenTaskInBackground?: (taskId: string) => void
@@ -327,6 +328,8 @@ function TaskRowView({
       data-task-id={task.id}
       data-active={isActive ? 'true' : undefined}
       data-selected={isSelected ? 'true' : undefined}
+      onFocus={() => ctx.onTaskPrefetch?.(task.id)}
+      onPointerEnter={() => ctx.onTaskPrefetch?.(task.id)}
       onClick={(e) => ctx.onRowSelectClick(e, task.id)}
       onAuxClick={(e) => {
         if (e.button !== 1) return
@@ -336,6 +339,7 @@ function TaskRowView({
         else ctx.onOpenTaskInBackground?.(task.id)
       }}
       onMouseDown={(e) => {
+        if (e.button === 0) ctx.onTaskPrefetch?.(task.id)
         if (e.button === 1) e.preventDefault()
       }}
       style={{ ...style, paddingLeft: tgPaddingLeft(depth), minHeight: TG_ROW_HEIGHT }}
@@ -853,6 +857,7 @@ export function TreeView({
   onSelectProject,
   onProjectSettings,
   onTaskClick,
+  onTaskPrefetch,
   onCloseTab,
   onOpenTaskInBackground,
   onCreateTemporaryTask,
@@ -1394,11 +1399,12 @@ export function TreeView({
       }
 
       // Plain click — clear selection, set anchor, open task.
+      onTaskPrefetch?.(taskId)
       setSelectedTaskIds(new Set([taskId]))
       setSelectionAnchorId(taskId)
       onTaskClick?.(taskId)
     },
-    [selectionAnchorId, tasksById, getSiblings, onTaskClick]
+    [selectionAnchorId, tasksById, getSiblings, onTaskPrefetch, onTaskClick]
   )
 
   // Render-order list of moved task ids — the dragged set, in tree visual
@@ -1918,6 +1924,7 @@ export function TreeView({
       treeGroupBy,
       treeGroupPinned,
       onTaskClick,
+      onTaskPrefetch,
       onRowSelectClick: handleRowSelectClick,
       onCloseTab,
       onOpenTaskInBackground,

--- a/packages/apps/app/src/renderer/src/components/sidebar/views/types.ts
+++ b/packages/apps/app/src/renderer/src/components/sidebar/views/types.ts
@@ -11,6 +11,8 @@ export interface SidebarViewContext {
   onSelectProject: (id: string) => void
   onProjectSettings: (project: Project) => void
   onTaskClick?: (taskId: string) => void
+  /** Warm task detail data/module before the user commits to opening the task. */
+  onTaskPrefetch?: (taskId: string) => void
   /** Close a task tab by id (handles temporary task DB cleanup). */
   onCloseTab?: (taskId: string) => void
   /** Open a task as a background tab without changing focus. */

--- a/packages/domains/projects/src/client/ProjectSelect.tsx
+++ b/packages/domains/projects/src/client/ProjectSelect.tsx
@@ -6,18 +6,23 @@ interface ProjectSelectProps {
   value: string | undefined
   onChange: (value: string) => void
   disabled?: boolean
+  projects?: Project[]
 }
 
 export function ProjectSelect({
   value,
   onChange,
-  disabled
+  disabled,
+  projects
 }: ProjectSelectProps): React.JSX.Element {
-  const [projects, setProjects] = useState<Project[]>([])
+  const [loadedProjects, setLoadedProjects] = useState<Project[]>([])
 
   useEffect(() => {
-    window.api.db.getProjects().then(setProjects)
-  }, [])
+    if (projects) return
+    window.api.db.getProjects().then(setLoadedProjects)
+  }, [projects])
+
+  const options = projects ?? loadedProjects
 
   return (
     <Select value={value} onValueChange={onChange} disabled={disabled}>
@@ -25,7 +30,7 @@ export function ProjectSelect({
         <SelectValue placeholder="Select project" />
       </SelectTrigger>
       <SelectContent>
-        {[...projects]
+        {[...options]
           .sort((a, b) => a.name.localeCompare(b.name))
           .map((project) => (
             <SelectItem key={project.id} value={project.id}>

--- a/packages/domains/settings/src/client/useTabStore.ts
+++ b/packages/domains/settings/src/client/useTabStore.ts
@@ -212,18 +212,20 @@ interface TabState {
 }
 
 function findWorktreeInsertIndex(taskId: string, tabs: Tab[], lookup: TaskLookup): number {
-  const task = lookup.tasks.find((t) => t.id === taskId)
+  const tasksById = new Map(lookup.tasks.map((t) => [t.id, t]))
+  const projectsById = new Map(lookup.projects.map((p) => [p.id, p]))
+  const task = tasksById.get(taskId)
   if (!task?.project_id) return tabs.length
-  const project = lookup.projects.find((p) => p.id === task.project_id)
+  const project = projectsById.get(task.project_id)
   const effectivePath = task.worktree_path || project?.path
   if (!effectivePath) return tabs.length
   let lastSibling = -1
   for (let i = tabs.length - 1; i >= 0; i--) {
     const tab = tabs[i]
     if (tab.type !== 'task') continue
-    const t = lookup.tasks.find((x) => x.id === tab.taskId)
+    const t = tasksById.get(tab.taskId)
     if (!t?.project_id) continue
-    const p = lookup.projects.find((pr) => pr.id === t.project_id)
+    const p = projectsById.get(t.project_id)
     const otherPath = t.worktree_path || p?.path
     if (otherPath === effectivePath) {
       lastSibling = i

--- a/packages/domains/task/src/client/CreateTaskDialog.tsx
+++ b/packages/domains/task/src/client/CreateTaskDialog.tsx
@@ -32,6 +32,7 @@ interface CreateTaskDialogProps {
   onCreatedAndOpen?: (task: Task) => void
   draft?: CreateTaskDraft
   tags: Tag[]
+  projects?: Project[]
   onTagCreated?: (tag: Tag) => void
 }
 
@@ -42,10 +43,10 @@ export function CreateTaskDialog({
   onCreatedAndOpen,
   draft,
   tags,
+  projects = [],
   onTagCreated
 }: CreateTaskDialogProps): React.JSX.Element {
   const [createTagOpen, setCreateTagOpen] = useState(false)
-  const [projects, setProjects] = useState<Project[]>([])
   const [templates, setTemplates] = useState<TaskTemplate[]>([])
   const [selectedTemplateId, setSelectedTemplateId] = useState<string>('__none__')
   const form = useForm<CreateTaskFormData>({
@@ -61,11 +62,6 @@ export function CreateTaskDialog({
     }
     prevOpenRef.current = open
   }, [open, draft, form])
-
-  useEffect(() => {
-    if (!open) return
-    window.api.db.getProjects().then((list) => setProjects(list))
-  }, [open])
 
   const selectedProjectId = form.watch('projectId')
   const selectedProject = projects.find((project) => project.id === selectedProjectId)
@@ -110,11 +106,11 @@ export function CreateTaskDialog({
     opts?: { statusOverride?: Task['status']; andOpen?: boolean }
   ): Promise<void> => {
     const isAutoCreateEnabledForProject = async (projectId: string): Promise<boolean> => {
-      const [globalSetting, projects] = await Promise.all([
+      const [globalSetting, availableProjects] = await Promise.all([
         window.api.settings.get('auto_create_worktree_on_task_create'),
-        window.api.db.getProjects()
+        projects.length > 0 ? Promise.resolve(projects) : window.api.db.getProjects()
       ])
-      const project = projects.find((p) => p.id === projectId)
+      const project = availableProjects.find((p) => p.id === projectId)
       const override = project?.auto_create_worktree_on_task_create
       if (override === 1) return true
       if (override === 0) return false
@@ -435,7 +431,11 @@ export function CreateTaskDialog({
                 <FormItem>
                   <FormLabel>Project</FormLabel>
                   <FormControl>
-                    <ProjectSelect value={field.value} onChange={field.onChange} />
+                    <ProjectSelect
+                      value={field.value}
+                      onChange={field.onChange}
+                      projects={projects}
+                    />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/packages/domains/task/src/client/TaskDetailPage.tsx
+++ b/packages/domains/task/src/client/TaskDetailPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react'
+import React, { useState, useEffect, useLayoutEffect, useRef, useCallback, useMemo } from 'react'
 import {
   MoreHorizontal,
   Archive,
@@ -435,6 +435,9 @@ export const TaskDetailPage = React.memo(function TaskDetailPage({
   // Prefer live global state; fall back to suspense-cached data for subtask race window
   const task = taskProp ?? initialData?.task ?? null
   const project = projectProp ?? initialData?.project ?? null
+  useLayoutEffect(() => {
+    if (task?.id) performance.mark(`sz:taskDetail:${task.id}:mount`)
+  }, [task?.id])
 
   // Owns keyboard shortcuts; falls back to isActive so non-explode callers need not set it.
   const shortcutActive = hasShortcutFocus ?? isActive
@@ -2181,7 +2184,11 @@ export const TaskDetailPage = React.memo(function TaskDetailPage({
   const isTaskCompleted = isCompletedStatus(task.status, project?.columns_config)
 
   return (
-    <div id="task-detail" className={cn('h-full flex flex-col', compact ? 'p-0' : 'gap-4')}>
+    <div
+      id="task-detail"
+      data-task-id={task.id}
+      className={cn('h-full flex flex-col', compact ? 'p-0' : 'gap-4')}
+    >
       {compact && (
         <div className="shrink-0 flex items-center gap-1.5 px-2 h-10 bg-surface-1 border-b border-border min-w-0">
           {!task.is_temporary &&

--- a/packages/domains/task/src/client/taskDetailCache.test.ts
+++ b/packages/domains/task/src/client/taskDetailCache.test.ts
@@ -135,6 +135,7 @@ describe('fetchTaskDetail', () => {
       diff: false,
       settings: true,
       editor: true,
+      artifacts: false,
       processes: false
     })
   })

--- a/packages/domains/task/src/client/taskDetailCache.ts
+++ b/packages/domains/task/src/client/taskDetailCache.ts
@@ -27,6 +27,15 @@ export interface TaskDetailData {
   browserTabs: BrowserTabsState
 }
 
+export interface TaskDetailSnapshotInput {
+  task: Task
+  tasks: Task[]
+  projects: Project[]
+  tags: Tag[]
+  taskTagIds: string[]
+  projectPathMissing?: boolean
+}
+
 async function checkProjectPathExists(path: string): Promise<boolean> {
   const pathExists = window.api.files?.pathExists
   if (typeof pathExists === 'function') return pathExists(path)
@@ -34,6 +43,55 @@ async function checkProjectPathExists(path: string): Promise<boolean> {
 }
 
 export { fetchTaskDetail }
+
+function getPanelVisibility(task: Task): PanelVisibility {
+  return {
+    ...DEFAULT_PANEL_VISIBILITY,
+    ...(task.panel_visibility ?? {}),
+    ...(task.is_temporary ? { settings: false } : {})
+  }
+}
+
+function getBrowserTabs(task: Task, tasks: Task[]): BrowserTabsState {
+  if (task.browser_tabs) return task.browser_tabs
+  let firstUrl = 'about:blank'
+  for (const t of tasks) {
+    if (t.id === task.id) continue
+    const url = t.browser_tabs?.tabs?.find((tab) => tab.url && tab.url !== 'about:blank')?.url
+    if (url) {
+      firstUrl = url
+      break
+    }
+  }
+  return {
+    tabs: [
+      { id: 'default', url: firstUrl, title: firstUrl === 'about:blank' ? 'New Tab' : firstUrl }
+    ],
+    activeTabId: 'default'
+  }
+}
+
+export function buildTaskDetailDataFromSnapshot({
+  task,
+  tasks,
+  projects,
+  tags,
+  taskTagIds,
+  projectPathMissing = false
+}: TaskDetailSnapshotInput): TaskDetailData {
+  const project = projects.find((p) => p.id === task.project_id) ?? null
+  return {
+    task,
+    project,
+    tags: tags.filter((t) => t.project_id === task.project_id),
+    taskTagIds,
+    subTasks: tasks.filter((t) => t.parent_id === task.id),
+    parentTask: task.parent_id ? (tasks.find((t) => t.id === task.parent_id) ?? null) : null,
+    projectPathMissing,
+    panelVisibility: getPanelVisibility(task),
+    browserTabs: getBrowserTabs(task, tasks)
+  }
+}
 
 async function fetchTaskDetail(taskId: string): Promise<TaskDetailData | null> {
   // Task fetch is critical — let it throw. Secondary data uses defaults on failure.
@@ -61,11 +119,7 @@ async function fetchTaskDetail(taskId: string): Promise<TaskDetailData | null> {
   }
 
   // Resolve panel visibility
-  const panelVisibility: PanelVisibility = {
-    ...DEFAULT_PANEL_VISIBILITY,
-    ...(loadedTask.panel_visibility ?? {}),
-    ...(loadedTask.is_temporary ? { settings: false } : {})
-  }
+  const panelVisibility = getPanelVisibility(loadedTask)
 
   // Resolve browser tabs (including fallback to first URL from other tasks)
   let browserTabs: BrowserTabsState
@@ -73,21 +127,7 @@ async function fetchTaskDetail(taskId: string): Promise<TaskDetailData | null> {
     browserTabs = loadedTask.browser_tabs
   } else {
     const allTasks = await window.api.db.getTasks()
-    let firstUrl = 'about:blank'
-    for (const t of allTasks) {
-      if (t.id === loadedTask.id) continue
-      const url = t.browser_tabs?.tabs?.find((tab) => tab.url && tab.url !== 'about:blank')?.url
-      if (url) {
-        firstUrl = url
-        break
-      }
-    }
-    browserTabs = {
-      tabs: [
-        { id: 'default', url: firstUrl, title: firstUrl === 'about:blank' ? 'New Tab' : firstUrl }
-      ],
-      activeTabId: 'default'
-    }
+    browserTabs = getBrowserTabs(loadedTask, allTasks)
   }
 
   return {

--- a/packages/domains/tasks/src/client/KanbanBoard.tsx
+++ b/packages/domains/tasks/src/client/KanbanBoard.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import {
   DndContext,
   DragOverlay,
@@ -104,14 +104,22 @@ export function KanbanBoard({
     useSensor(KeyboardSensor)
   )
 
-  const allColumns = groupTasksBy(tasks, groupBy, sortBy, projectColumns, {
-    blockedTaskIds,
-    viewConfig
-  })
-  const visibleColumns = showEmptyColumns
-    ? allColumns
-    : allColumns.filter((c) => c.tasks.length > 0)
-  const activeTask = activeId ? tasks.find((t) => t.id === activeId) : null
+  const allColumns = useMemo(
+    () =>
+      groupTasksBy(tasks, groupBy, sortBy, projectColumns, {
+        blockedTaskIds,
+        viewConfig
+      }),
+    [tasks, groupBy, sortBy, projectColumns, blockedTaskIds, viewConfig]
+  )
+  const visibleColumns = useMemo(
+    () => (showEmptyColumns ? allColumns : allColumns.filter((c) => c.tasks.length > 0)),
+    [showEmptyColumns, allColumns]
+  )
+  const activeTask = useMemo(
+    () => (activeId ? tasks.find((t) => t.id === activeId) : null),
+    [activeId, tasks]
+  )
 
   const selection = useKanbanSelection({ columns: visibleColumns, resetKey: selectionResetKey })
 
@@ -120,19 +128,25 @@ export function KanbanBoard({
   const [dragSetSize, setDragSetSize] = useState(1)
 
   // Wrap onTaskClick: shift = toggle selection (no open); meta = bg open (existing); plain = clear + open
-  const handleCardClick = (task: Task, e: { metaKey: boolean; shiftKey?: boolean }): void => {
-    if (e.shiftKey) {
-      selection.toggle(task.id)
-      return
-    }
-    if (!e.metaKey) selection.clear()
-    onTaskClick?.(task, e)
-  }
+  const handleCardClick = useCallback(
+    (task: Task, e: { metaKey: boolean; shiftKey?: boolean }): void => {
+      if (e.shiftKey) {
+        selection.toggle(task.id)
+        return
+      }
+      if (!e.metaKey) selection.clear()
+      onTaskClick?.(task, e)
+    },
+    [selection.toggle, selection.clear, onTaskClick]
+  )
 
   // Right-click intercept: if not in selection, replace with this card; else keep selection
-  const handleCardContextMenu = (taskId: string): void => {
-    if (!selection.selectedIds.has(taskId)) selection.replace(taskId)
-  }
+  const handleCardContextMenu = useCallback(
+    (taskId: string): void => {
+      if (!selection.selectedIds.has(taskId)) selection.replace(taskId)
+    },
+    [selection.selectedIds, selection.replace]
+  )
 
   const subTaskCounts = useMemo(() => {
     const counts = new Map<string, { done: number; total: number }>()

--- a/packages/domains/tasks/src/client/KanbanCard.tsx
+++ b/packages/domains/tasks/src/client/KanbanCard.tsx
@@ -6,7 +6,6 @@ import { TagSelector } from '@slayzone/tags/client'
 import type { ColumnConfig } from '@slayzone/projects/shared'
 import { isCompletedStatus, isTerminalStatus } from '@slayzone/projects/shared'
 import { TaskProgressPopover } from '@slayzone/task/client'
-import type { TerminalState } from '@slayzone/terminal/shared'
 import {
   Card,
   CardContent,
@@ -25,7 +24,7 @@ import { useAppearance } from '@slayzone/settings/client'
 import { todayISO } from './kanban'
 import { priorityOptions } from '@slayzone/task/shared'
 import { AlarmClockOff, GitMerge } from 'lucide-react'
-import { usePty } from '@slayzone/terminal'
+import { useKnownTaskTerminalState } from '@slayzone/terminal'
 import type { CardProperties } from './FilterState'
 
 function formatTimeLeft(until: string): string {
@@ -82,15 +81,7 @@ export function KanbanCard({
   const prevStatusRef = useRef(task.status)
   const [justCompleted, setJustCompleted] = useState(false)
 
-  // Terminal state tracking - use main terminal sessionId format (taskId:taskId)
-  const { getState, subscribeState } = usePty()
-  const mainSessionId = `${task.id}:${task.id}`
-  const [terminalState, setTerminalState] = useState<TerminalState>(() => getState(mainSessionId))
-
-  useEffect(() => {
-    setTerminalState(getState(mainSessionId))
-    return subscribeState(mainSessionId, (newState) => setTerminalState(newState))
-  }, [mainSessionId, getState, subscribeState])
+  const terminalState = useKnownTaskTerminalState(task.id)
 
   useEffect(() => {
     if (

--- a/packages/domains/tasks/src/client/KanbanListView.tsx
+++ b/packages/domains/tasks/src/client/KanbanListView.tsx
@@ -22,7 +22,6 @@ import type { Task } from '@slayzone/task/shared'
 import type { Project } from '@slayzone/projects/shared'
 import type { ColumnConfig } from '@slayzone/projects/shared'
 import { isTerminalStatus } from '@slayzone/projects/shared'
-import type { TerminalState } from '@slayzone/terminal/shared'
 import type { Tag } from '@slayzone/tags/shared'
 import {
   groupTasksBy,
@@ -45,9 +44,8 @@ import {
 } from '@slayzone/ui'
 import { IconButton } from '@slayzone/ui'
 import { ChevronDown, Plus, AlertCircle, AlarmClockOff, Check, GitMerge, Link2 } from 'lucide-react'
-import { usePty, useActiveTaskIds } from '@slayzone/terminal'
+import { useActiveTaskIds, useKnownTaskTerminalState } from '@slayzone/terminal'
 import { useDialogStore } from '@slayzone/settings/client'
-import { useEffect } from 'react'
 
 function formatSnoozeTimeLeft(until: string): string {
   const ms = new Date(until).getTime() - Date.now()
@@ -98,14 +96,7 @@ function PriorityBar({ priority }: { priority: number }): React.JSX.Element {
 // ── Terminal state dot ──
 
 function TerminalDot({ taskId }: { taskId: string }): React.JSX.Element | null {
-  const { getState, subscribeState } = usePty()
-  const sessionId = `${taskId}:${taskId}`
-  const [terminalState, setTerminalState] = useState<TerminalState>(() => getState(sessionId))
-
-  useEffect(() => {
-    setTerminalState(getState(sessionId))
-    return subscribeState(sessionId, (s) => setTerminalState(s))
-  }, [sessionId, getState, subscribeState])
+  const terminalState = useKnownTaskTerminalState(taskId)
 
   if (terminalState === 'starting') return null
   const style = getTerminalStateStyle(terminalState)

--- a/packages/domains/tasks/src/client/useKanbanSelection.ts
+++ b/packages/domains/tasks/src/client/useKanbanSelection.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { Column } from './kanban'
 
 export interface KanbanSelectionAPI {
@@ -76,14 +76,17 @@ export function useKanbanSelection({
     setAnchorId(ids[ids.length - 1] ?? null)
   }, [])
 
-  return {
-    selectedIds,
-    anchorId,
-    isSelected,
-    toggle,
-    replace,
-    clear,
-    selectAll,
-    size: selectedIds.size
-  }
+  return useMemo(
+    () => ({
+      selectedIds,
+      anchorId,
+      isSelected,
+      toggle,
+      replace,
+      clear,
+      selectAll,
+      size: selectedIds.size
+    }),
+    [selectedIds, anchorId, isSelected, toggle, replace, clear, selectAll]
+  )
 }

--- a/packages/domains/terminal/src/client/PtyContext.tsx
+++ b/packages/domains/terminal/src/client/PtyContext.tsx
@@ -38,6 +38,10 @@ function taskIdFromSessionId(sessionId: string): string {
   return idx >= 0 ? sessionId.substring(0, idx) : sessionId
 }
 
+function isAliveState(state: TerminalState): boolean {
+  return ALIVE_STATES.has(state)
+}
+
 export function applyExitEvent(
   sessionId: string,
   exitCode: number,
@@ -123,7 +127,7 @@ export function PtyProvider({ children }: { children: ReactNode }) {
     setActiveTaskIds((prev) => {
       const next = new Set<string>()
       for (const [sid, s] of statesRef.current) {
-        if (ALIVE_STATES.has(s.state)) next.add(taskIdFromSessionId(sid))
+        if (isAliveState(s.state)) next.add(taskIdFromSessionId(sid))
       }
       // Avoid new reference if nothing changed
       if (next.size === prev.size && [...next].every((id) => prev.has(id))) return prev
@@ -139,7 +143,7 @@ export function PtyProvider({ children }: { children: ReactNode }) {
     performance.mark('sz:pty:start')
     window.api.session.list().then((sessions) => {
       for (const s of sessions) {
-        if (ALIVE_STATES.has(s.state)) {
+        if (isAliveState(s.state)) {
           const sid = s.sessionId
           const existing = statesRef.current.get(sid)
           if (existing) {
@@ -245,15 +249,12 @@ export function PtyProvider({ children }: { children: ReactNode }) {
       }
 
       // Update active task tracking
-      const wasAlive = ALIVE_STATES.has(oldState as TerminalState)
-      const isAlive = ALIVE_STATES.has(newState as TerminalState)
+      const wasAlive = isAliveState(oldState as TerminalState)
+      const isAlive = isAliveState(newState as TerminalState)
       if (wasAlive !== isAlive) refreshActiveTaskIds()
 
-      // Clear pending prompt when state leaves the alive set (e.g. dead/error)
-      if (
-        ALIVE_STATES.has(oldState as TerminalState) &&
-        !ALIVE_STATES.has(newState as TerminalState)
-      ) {
+      // Clear pending prompt when state leaves the alive set.
+      if (isAliveState(oldState as TerminalState) && !isAliveState(newState as TerminalState)) {
         state.pendingPrompt = undefined
         setPendingPromptTaskIds((prev) => {
           const next = new Set(prev)
@@ -385,7 +386,7 @@ export function PtyProvider({ children }: { children: ReactNode }) {
                 currentSubs.forEach((sub) => sub(backendState, oldState))
               }
               // Update active task tracking
-              if (ALIVE_STATES.has(backendState)) refreshActiveTaskIds()
+              if (isAliveState(backendState)) refreshActiveTaskIds()
             }
           }
         })
@@ -623,4 +624,26 @@ export function usePendingPrompts(): string[] {
  */
 export function useActiveTaskIds(): Set<string> {
   return useContext(ActiveTaskIdsContext)
+}
+
+export function useKnownTaskTerminalState(taskId: string): TerminalState | undefined {
+  const activeTaskIds = useActiveTaskIds()
+  const shouldSubscribe = activeTaskIds.has(taskId)
+  const sessionId = `${taskId}:${taskId}`
+  const { getState, subscribeState } = usePty()
+  const [terminalState, setTerminalState] = useState<TerminalState | undefined>(() =>
+    shouldSubscribe ? getState(sessionId) : undefined
+  )
+
+  useEffect(() => {
+    if (!shouldSubscribe) {
+      setTerminalState(undefined)
+      return
+    }
+
+    setTerminalState(getState(sessionId))
+    return subscribeState(sessionId, (newState) => setTerminalState(newState))
+  }, [shouldSubscribe, sessionId, getState, subscribeState])
+
+  return terminalState
 }

--- a/packages/domains/terminal/src/client/index.ts
+++ b/packages/domains/terminal/src/client/index.ts
@@ -3,7 +3,13 @@ export {
   TerminalStatusButton,
   TerminalStatusDialog
 } from './TerminalStatusPopover'
-export { PtyProvider, usePty, usePendingPrompts, useActiveTaskIds } from './PtyContext'
+export {
+  PtyProvider,
+  usePty,
+  usePendingPrompts,
+  useActiveTaskIds,
+  useKnownTaskTerminalState
+} from './PtyContext'
 export {
   PtyStateDot,
   PtyProgressDot,

--- a/packages/shared/platform/src/cli-install.ts
+++ b/packages/shared/platform/src/cli-install.ts
@@ -20,19 +20,21 @@ export function getCliBinDir(): string {
     case 'darwin':
       return '/usr/local/bin'
     case 'win32':
-      return path.join(
+      return path.win32.join(
         process.env.LOCALAPPDATA ?? path.join(os.homedir(), 'AppData', 'Local'),
         'SlayZone',
         'bin'
       )
     default:
-      return path.join(os.homedir(), '.local', 'bin')
+      return path.posix.join(os.homedir(), '.local', 'bin')
   }
 }
 
 export function getCliBinTarget(): string {
   const name = process.platform === 'win32' ? 'slay.cmd' : 'slay'
-  return path.join(getCliBinDir(), name)
+  return process.platform === 'win32'
+    ? path.win32.join(getCliBinDir(), name)
+    : path.posix.join(getCliBinDir(), name)
 }
 
 export function checkCliInstalled(): { installed: boolean; path?: string } {

--- a/packages/shared/platform/src/migrations.test.ts
+++ b/packages/shared/platform/src/migrations.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 import os from 'os'
-import { describe, test, expect } from 'vitest'
+import { describe, test, expect, vi } from 'vitest'
 import { migrateStateDir, copyVerifyDelete } from './migrations'
 
 function tmpDir(): string {
@@ -117,27 +117,24 @@ describe('migrateStateDir', () => {
 
   // --- Failure / rollback ---
 
-  test('fails and rolls back when newDir parent is not writable', () => {
-    if (process.getuid?.() === 0) {
-      return // skip when running as root
-    }
+  test('fails and preserves oldDir when rename fails', () => {
     const root = tmpDir()
     const oldDir = path.join(root, 'old')
-    const lockedParent = path.join(root, 'locked')
-    const newDir = path.join(lockedParent, 'new')
+    const newDir = path.join(root, 'new')
     fs.mkdirSync(oldDir)
     fs.writeFileSync(path.join(oldDir, 'slayzone.sqlite'), 'important')
-    // Create parent then remove write permission
-    fs.mkdirSync(lockedParent)
-    fs.chmodSync(lockedParent, 0o555)
+    const renameSync = vi.spyOn(fs, 'renameSync').mockImplementation(() => {
+      const err = new Error('EACCES') as NodeJS.ErrnoException
+      err.code = 'EACCES'
+      throw err
+    })
     try {
       const result = migrateStateDir(oldDir, newDir)
       expect(result.migrated).toBe(false)
       expect(result.failed).toBe(true)
-      // Old dir preserved
       expect(fs.readFileSync(path.join(oldDir, 'slayzone.sqlite'), 'utf8')).toBe('important')
     } finally {
-      fs.chmodSync(lockedParent, 0o755)
+      renameSync.mockRestore()
       cleanup(root)
     }
   })

--- a/packages/shared/suspense/src/suspense-cache.test.tsx
+++ b/packages/shared/suspense/src/suspense-cache.test.tsx
@@ -49,6 +49,29 @@ describe('createSuspenseCache', () => {
     expect(fetcher).toHaveBeenCalledTimes(1)
   })
 
+  it('returns primed data without fetching', async () => {
+    const fetcher = vi.fn(() => Promise.resolve('from-fetch'))
+    const cache = createSuspenseCache({ item: fetcher })
+    cache.prime('item', ['a'], 'primed')
+
+    function Inner() {
+      const data = cache.useData('item', 'a')
+      return <div data-testid="result">{data}</div>
+    }
+
+    await act(async () => {
+      render(
+        <Suspense fallback={<div data-testid="fallback">loading</div>}>
+          <Inner />
+        </Suspense>
+      )
+    })
+
+    expect(screen.getByTestId('result').textContent).toBe('primed')
+    expect(screen.queryByTestId('fallback')).toBeNull()
+    expect(fetcher).not.toHaveBeenCalled()
+  })
+
   it('caches separately by args', async () => {
     const fetcher = vi.fn((id: string) => Promise.resolve(id))
     const cache = createSuspenseCache({ item: fetcher })

--- a/packages/shared/suspense/src/suspense-cache.ts
+++ b/packages/shared/suspense/src/suspense-cache.ts
@@ -32,6 +32,13 @@ export interface SuspenseCache<F extends Fetchers> {
   /** Start fetching data without suspending. Warms the cache so useData resolves instantly. */
   prefetch<K extends keyof F & string>(key: K, ...args: FetcherArgs<F[K]>): void
 
+  /** Seed a resolved cache entry from already-loaded app state. */
+  prime<K extends keyof F & string>(
+    key: K,
+    args: FetcherArgs<F[K]>,
+    value: FetcherReturn<F[K]>
+  ): void
+
   /** Invalidate a specific cache entry. Triggers re-render → re-suspend. */
   invalidate<K extends keyof F & string>(key: K, ...args: FetcherArgs<F[K]>): void
 
@@ -111,6 +118,17 @@ export function createSuspenseCache<F extends Fetchers>(fetchers: F): SuspenseCa
 
     prefetch(key, ...args) {
       getOrFetch(key, args)
+    },
+
+    prime(key, args, value) {
+      const k = cacheKey(key, args)
+      const existing = cache.get(k)
+      cache.set(k, {
+        promise: Promise.resolve(value),
+        value,
+        settled: true
+      })
+      if (existing && !existing.settled) notify()
     },
 
     invalidate(key, ...args) {


### PR DESCRIPTION
## Summary

Optimizes opening a task from the sidebar by:
- Prime the task detail Suspense cache from sidebar and board state before opening a known task.
- Reuse task and project lookup maps instead of repeatedly scanning arrays on task-open paths.
- Reduce avoidable task, kanban, project select, and terminal re-renders in related open/selection flows.
- Add focused coverage for Suspense cache priming and closed-task sidebar open performance.

## Root Cause

Opening a task from the sidebar could still suspend on task detail data even when the current app state already had enough task, project, panel, and browser-tab data to render the detail page. Some adjacent open paths also rebuilt lookup state or re-rendered more work than needed.

## Fix Details

- Added `SuspenseCache.prime(...)` so known resolved data can enter the cache without throwing a pending promise.
- Added task detail snapshot builders that mirror the async fetch shape, then prime the cache before task open.
- Prefetch task detail on sidebar row hover, focus, mousedown, and click.
- Optimized tab insertion and selection helpers with maps and memoized state.
- Added a focused Playwright perf scenario for opening a closed task from the sidebar.

## Performance Numbers Seen

Focused scenario: `open-closed-task-from-sidebar`.

Before:
- p50: 676 ms
- p95: 1176 ms
- Detail loading shell commonly waited around 400 ms before render

After:
- p50: 313 ms
- p95: 391 ms
- Task detail mount mark observed around 100-190 ms
- Known sidebar tasks no longer showed the Suspense shell before detail render

## Validation

In the fresh worktree/branch:

- `pnpm install --frozen-lockfile`
- `pnpm --filter @slayzone/app typecheck`
- `pnpm --filter @slayzone/app exec vitest run --root ../../.. packages/shared/suspense/src/suspense-cache.test.tsx packages/domains/task/src/client/taskDetailCache.test.ts`

Earlier validation from the source branch:

- `npx playwright test --config playwright.config.ts e2e/perf/scenarios.spec.ts -g open-closed-task-from-sidebar`
- `pnpm build:mac`


## CI Note

The initial PR run failed in `check-windows` inside `packages/shared/platform`, not in the performance code. Latest `main` had the same `check-windows` platform failures on May 23, 2026. This PR includes a small follow-up fix to make those platform shell tests portable on Windows:

- Use the target platform path separator when computing CLI install paths under mocked platforms.
- Simulate migration rename failure directly instead of relying on chmod-based unwritable directories, which do not behave the same on Windows.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR speeds up task-opening paths by priming task detail data and reducing repeated lookup work. The main changes are:

- Added Suspense cache priming for known task detail snapshots.
- Prefetched task detail data from sidebar row hover, focus, mouse down, and click paths.
- Reused task and project lookup maps across task open and rendering flows.
- Reduced terminal state subscriptions in kanban card and list views.
- Added a focused perf scenario and adjusted platform tests for Windows portability.
</details>


<details><summary><h3>Confidence Score: 3/5</h3></summary>

These issues should be fixed before merging.

- Opening a task from another project can briefly render with the wrong project-path status.
- Kanban and list views can stop showing terminal error or stopped states.
- The create task dialog no longer self-loads projects when used without an injected list.

Focus on `App.tsx`, `PtyContext.tsx`, and `CreateTaskDialog.tsx`.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/apps/app/src/renderer/src/App.tsx | Adds task detail snapshot priming and lookup maps, with a wrong project-path snapshot for cross-project opens. |
| packages/domains/terminal/src/client/PtyContext.tsx | Adds a narrower terminal-state hook that hides non-alive terminal states from kanban/list consumers. |
| packages/domains/task/src/client/CreateTaskDialog.tsx | Switches project options to injected data, changing standalone dialog behavior when no projects prop is supplied. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/domains/task/src/client/CreateTaskDialog.tsx`, line 39-48 ([link](https://github.com/debuglebowski/slayzone/blob/cf083f0095d942c553afd0a7a3684b43d53ef6a6/packages/domains/task/src/client/CreateTaskDialog.tsx#L39-L48)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Standalone project list breaks** `projects` now defaults to an empty array, and the dialog always passes that array into `ProjectSelect`. Since `ProjectSelect` treats any provided array as controlled and skips loading from the DB, any caller that omits `projects` gets an empty project dropdown instead of the previous self-loading behavior.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: packages/domains/task/src/client/CreateTaskDialog.tsx
   Line: 39-48

   Comment:
   **Standalone project list breaks** `projects` now defaults to an empty array, and the dialog always passes that array into `ProjectSelect`. Since `ProjectSelect` treats any provided array as controlled and skips loading from the DB, any caller that omits `projects` gets an empty project dropdown instead of the previous self-loading behavior.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
packages/apps/app/src/renderer/src/App.tsx:671-678
**Wrong path status** This snapshot only carries the cached `projectPathMissing` value when the opened task belongs to the currently selected project. The sidebar can open tasks from other projects, so a task whose own project path is missing gets primed with `projectPathMissing: false` and the detail page renders repo-dependent UI before its async recheck corrects the state.

### Issue 2 of 3
packages/domains/terminal/src/client/PtyContext.tsx:629-646
**Terminal errors disappear** This hook only returns a state while `activeTaskIds` contains the task, but that set only tracks alive terminals (`running` and `idle`). When a terminal enters `error` or `dead`, kanban cards and list rows now receive `undefined` and hide the red/stopped indicator that the previous direct subscription could display.

### Issue 3 of 3
packages/domains/task/src/client/CreateTaskDialog.tsx:39-48
**Standalone project list breaks** `projects` now defaults to an empty array, and the dialog always passes that array into `ProjectSelect`. Since `ProjectSelect` treats any provided array as controlled and skips loading from the DB, any caller that omits `projects` gets an empty project dropdown instead of the previous self-loading behavior.

```suggestion
export function CreateTaskDialog({
  open,
  onOpenChange,
  onCreated,
  onCreatedAndOpen,
  draft,
  tags,
  projects,
  onTagCreated
}: CreateTaskDialogProps): React.JSX.Element {
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(platform): make shell tests portable"](https://github.com/debuglebowski/slayzone/commit/cf083f0095d942c553afd0a7a3684b43d53ef6a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34588821)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->