### PR TITLE
[codex] fix terminal Mac Option symbols

### DIFF
--- a/packages/apps/app/e2e/terminal/30-terminal-core-behavior.spec.ts
+++ b/packages/apps/app/e2e/terminal/30-terminal-core-behavior.spec.ts
@@ -123,6 +123,54 @@ test.describe('Terminal state transitions', () => {
   })
 })
 
+// ── Keyboard input ──────────────────────────────────────────────────────────
+
+test.describe('Terminal keyboard input', () => {
+  let projectAbbrev: string
+  let taskId: string
+
+  test.beforeAll(async ({ mainWindow }) => {
+    const s = seed(mainWindow)
+    const p = await s.createProject({
+      name: 'Keyboard Input',
+      color: '#06b6d4',
+      path: TEST_PROJECT_PATH
+    })
+    projectAbbrev = p.name.slice(0, 2).toUpperCase()
+
+    const t = await s.createTask({
+      projectId: p.id,
+      title: 'Keyboard input task',
+      status: 'in_progress'
+    })
+    taskId = t.id
+
+    await mainWindow.evaluate(
+      (id) => window.api.db.updateTask({ id, terminalMode: 'terminal' }),
+      taskId
+    )
+    await s.refreshData()
+  })
+
+  test('lets macOS Option produce printable keyboard-layout characters', async ({ mainWindow }) => {
+    await openTaskTerminal(mainWindow, { projectAbbrev, taskTitle: 'Keyboard input task' })
+
+    const sessionId = getMainSessionId(taskId)
+    await waitForPtySession(mainWindow, sessionId)
+
+    await expect
+      .poll(async () =>
+        mainWindow.evaluate((sid) => {
+          const links = (window as any).__slayzone_terminalLinks as
+            | Record<string, { _terminal?: { options?: { macOptionIsMeta?: boolean } } }>
+            | undefined
+          return links?.[sid]?._terminal?.options?.macOptionIsMeta ?? null
+        }, sessionId)
+      )
+      .toBe(false)
+  })
+})
+
 // ── Mode switch teardown ────────────────────────────────────────────────────
 
 test.describe('Terminal mode switch teardown', () => {

--- a/packages/domains/terminal/src/client/Terminal.tsx
+++ b/packages/domains/terminal/src/client/Terminal.tsx
@@ -28,6 +28,10 @@ const trimSelectionTrailingSpaces = (s: string): string =>
     .map((l) => l.replace(/[ \t]+$/, ''))
     .join('\n')
 
+// Keep Option available for keyboard-layout chars ($, €, etc.). Option+Arrow
+// word nav is handled explicitly in handleTerminalKeyEvent.
+const MAC_OPTION_IS_META = false
+
 // Override xterm underline styles - Claude Code outputs these and they persist incorrectly
 // This is a definitive fix that works regardless of ANSI code filtering
 const underlineOverride = document.createElement('style')
@@ -420,6 +424,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
             searchAddonRef.current = cached.searchAddon
             webglAddonRef.current = cached.webglAddon ?? null
             registerActiveAddon(sessionId, cached.serializeAddon)
+            cached.terminal.options.macOptionIsMeta = MAC_OPTION_IS_META
             if (cached.lastRenderedSeq !== undefined) {
               lastRenderedSeqRef.current = cached.lastRenderedSeq
             }
@@ -544,7 +549,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
         // Create new terminal
         const terminal = new XTerm({
           allowProposedApi: true,
-          macOptionIsMeta: true,
+          macOptionIsMeta: MAC_OPTION_IS_META,
           cursorBlink: false,
           fontSize: terminalFontSize,
           fontFamily: terminalFontFamily,


### PR DESCRIPTION
## Problem

On macOS, the embedded terminal did not allow keyboard-layout characters produced with the Option key. In practice this meant users could not type currency symbols such as Option+3 for `$` or Option+4 for `€` in the terminal.

## Root cause

The xterm instance was created with `macOptionIsMeta: true`. That makes xterm treat Option as Meta and convert Option-key input into escape/meta sequences instead of allowing macOS keyboard layouts to emit printable characters.

## Fix

- Set `macOptionIsMeta` to `false` for new terminal instances so Option remains available for printable layout characters.
- Apply the same option when cached terminal instances are reattached, so existing xterm caches pick up the behavior.
- Keep Option+Left and Option+Right word navigation through the existing custom key handler.
- Add an e2e guard that asserts the terminal keeps macOS Option available for printable characters.

## Validation

- `pnpm --filter @slayzone/app build`
- `pnpm --filter @slayzone/terminal typecheck`
- `pnpm --filter @slayzone/app exec playwright test --config playwright.config.ts e2e/terminal/30-terminal-core-behavior.spec.ts -g "lets macOS Option"`
