### PR TITLE
feat(tasks): Cmd+Option+Left/Right to cycle task tabs

### DIFF
--- a/packages/apps/app/e2e/core/16-tab-management.spec.ts
+++ b/packages/apps/app/e2e/core/16-tab-management.spec.ts
@@ -245,24 +245,6 @@ test.describe('Tab management & keyboard shortcuts', () => {
     expect(await getActiveTabTitle(mainWindow)).toBe('Tab task A')
   })
 
-  test('Cmd+3 jumps to the 3rd task tab; Cmd+9 is a no-op when fewer than 9 tabs', async ({
-    mainWindow
-  }) => {
-    // With 3 task tabs open, Cmd+N is an indexed jump (Cmd+N → Nth task tab).
-    await mainWindow.keyboard.press('Meta+1')
-    await expect(
-      mainWindow.locator('[data-testid="terminal-mode-trigger"]:visible').first()
-    ).toBeVisible({ timeout: 5_000 })
-    expect(await getActiveTabTitle(mainWindow)).toBe('Tab task A')
-
-    await mainWindow.keyboard.press('Meta+3')
-    expect(await getActiveTabTitle(mainWindow)).toBe('Tab task C')
-
-    // Cmd+9 with only 3 task tabs open is a no-op (no 9th tab to jump to).
-    await mainWindow.keyboard.press('Meta+9')
-    expect(await getActiveTabTitle(mainWindow)).toBe('Tab task C')
-  })
-
   test('Cmd+Option+Right/Left from home jumps to first / last task tab', async ({ mainWindow }) => {
     await goHome(mainWindow)
     // Home tab active — next jumps to FIRST task tab.

--- a/packages/apps/app/e2e/core/16-tab-management.spec.ts
+++ b/packages/apps/app/e2e/core/16-tab-management.spec.ts
@@ -245,14 +245,20 @@ test.describe('Tab management & keyboard shortcuts', () => {
     expect(await getActiveTabTitle(mainWindow)).toBe('Tab task A')
   })
 
-  test('Cmd+9 jumps to the last task tab', async ({ mainWindow }) => {
-    // With 3 task tabs open, Cmd+9 (Chrome-style) should jump to the LAST task tab.
+  test('Cmd+3 jumps to the 3rd task tab; Cmd+9 is a no-op when fewer than 9 tabs', async ({
+    mainWindow
+  }) => {
+    // With 3 task tabs open, Cmd+N is an indexed jump (Cmd+N → Nth task tab).
     await mainWindow.keyboard.press('Meta+1')
     await expect(
       mainWindow.locator('[data-testid="terminal-mode-trigger"]:visible').first()
     ).toBeVisible({ timeout: 5_000 })
     expect(await getActiveTabTitle(mainWindow)).toBe('Tab task A')
 
+    await mainWindow.keyboard.press('Meta+3')
+    expect(await getActiveTabTitle(mainWindow)).toBe('Tab task C')
+
+    // Cmd+9 with only 3 task tabs open is a no-op (no 9th tab to jump to).
     await mainWindow.keyboard.press('Meta+9')
     expect(await getActiveTabTitle(mainWindow)).toBe('Tab task C')
   })

--- a/packages/apps/app/e2e/core/16-tab-management.spec.ts
+++ b/packages/apps/app/e2e/core/16-tab-management.spec.ts
@@ -12,6 +12,16 @@ async function getVisibleInputValue(page: import('@playwright/test').Page): Prom
   })
 }
 
+/** Read the title of the currently-active tab from the tab store. Task tabs
+ *  stay mounted (display:none) so all their <input>s remain visible per the
+ *  layout; only the store knows which one is actually active. */
+async function getActiveTabTitle(page: import('@playwright/test').Page): Promise<string | null> {
+  return page.evaluate(() => {
+    const s = (window as any).__slayzone_tabStore.getState()
+    return s.tabs[s.activeTabIndex]?.title ?? null
+  })
+}
+
 test.describe('Tab management & keyboard shortcuts', () => {
   let projectAbbrev: string
 
@@ -172,5 +182,90 @@ test.describe('Tab management & keyboard shortcuts', () => {
 
     const value = await getVisibleInputValue(mainWindow)
     expect(value).toBe('Tab task A')
+  })
+
+  test('Cmd+Option+Right cycles forward through task tabs and wraps', async ({ mainWindow }) => {
+    // Ensure all 3 task tabs (A, B, C) are open, then start on the first one.
+    for (const title of ['Tab task A', 'Tab task B', 'Tab task C']) {
+      await goHome(mainWindow)
+      await expect(mainWindow.getByText(title).first()).toBeVisible({ timeout: 5_000 })
+      await mainWindow.getByText(title).first().click()
+      await expect(
+        mainWindow.locator('[data-testid="terminal-mode-trigger"]:visible').first()
+      ).toBeVisible({ timeout: 5_000 })
+    }
+    await mainWindow.keyboard.press('Meta+1')
+    await expect(
+      mainWindow.locator('[data-testid="terminal-mode-trigger"]:visible').first()
+    ).toBeVisible({ timeout: 5_000 })
+    expect(await getActiveTabTitle(mainWindow)).toBe('Tab task A')
+
+    await mainWindow.keyboard.press('Meta+Alt+ArrowRight')
+    expect(await getActiveTabTitle(mainWindow)).toBe('Tab task B')
+
+    await mainWindow.keyboard.press('Meta+Alt+ArrowRight')
+    expect(await getActiveTabTitle(mainWindow)).toBe('Tab task C')
+
+    // Wrap-around: last → first
+    await mainWindow.keyboard.press('Meta+Alt+ArrowRight')
+    expect(await getActiveTabTitle(mainWindow)).toBe('Tab task A')
+  })
+
+  test('Cmd+Option+Left cycles backward through task tabs and wraps', async ({ mainWindow }) => {
+    await mainWindow.keyboard.press('Meta+1')
+    await expect(
+      mainWindow.locator('[data-testid="terminal-mode-trigger"]:visible').first()
+    ).toBeVisible({ timeout: 5_000 })
+    expect(await getActiveTabTitle(mainWindow)).toBe('Tab task A')
+
+    // Wrap-around: first → last
+    await mainWindow.keyboard.press('Meta+Alt+ArrowLeft')
+    expect(await getActiveTabTitle(mainWindow)).toBe('Tab task C')
+
+    await mainWindow.keyboard.press('Meta+Alt+ArrowLeft')
+    expect(await getActiveTabTitle(mainWindow)).toBe('Tab task B')
+
+    await mainWindow.keyboard.press('Meta+Alt+ArrowLeft')
+    expect(await getActiveTabTitle(mainWindow)).toBe('Tab task A')
+  })
+
+  test('Cmd+Option+Right is suppressed while focused in a text input', async ({ mainWindow }) => {
+    await mainWindow.keyboard.press('Meta+1')
+    await expect(
+      mainWindow.locator('[data-testid="terminal-mode-trigger"]:visible').first()
+    ).toBeVisible({ timeout: 5_000 })
+    expect(await getActiveTabTitle(mainWindow)).toBe('Tab task A')
+
+    // Focus the visible task title input (an <input>) — guard should NOT switch tabs.
+    const titleInput = mainWindow.locator('input:visible').first()
+    await titleInput.focus()
+    await mainWindow.keyboard.press('Meta+Alt+ArrowRight')
+
+    // Active task tab is unchanged.
+    expect(await getActiveTabTitle(mainWindow)).toBe('Tab task A')
+  })
+
+  test('Cmd+9 jumps to the last task tab', async ({ mainWindow }) => {
+    // With 3 task tabs open, Cmd+9 (Chrome-style) should jump to the LAST task tab.
+    await mainWindow.keyboard.press('Meta+1')
+    await expect(
+      mainWindow.locator('[data-testid="terminal-mode-trigger"]:visible').first()
+    ).toBeVisible({ timeout: 5_000 })
+    expect(await getActiveTabTitle(mainWindow)).toBe('Tab task A')
+
+    await mainWindow.keyboard.press('Meta+9')
+    expect(await getActiveTabTitle(mainWindow)).toBe('Tab task C')
+  })
+
+  test('Cmd+Option+Right/Left from home jumps to first / last task tab', async ({ mainWindow }) => {
+    await goHome(mainWindow)
+    // Home tab active — next jumps to FIRST task tab.
+    await mainWindow.keyboard.press('Meta+Alt+ArrowRight')
+    expect(await getActiveTabTitle(mainWindow)).toBe('Tab task A')
+
+    await goHome(mainWindow)
+    // Home tab active — prev jumps to LAST task tab.
+    await mainWindow.keyboard.press('Meta+Alt+ArrowLeft')
+    expect(await getActiveTabTitle(mainWindow)).toBe('Tab task C')
   })
 })

--- a/packages/apps/app/src/renderer/src/app-shell/useAppShortcuts.ts
+++ b/packages/apps/app/src/renderer/src/app-shell/useAppShortcuts.ts
@@ -184,15 +184,11 @@ export function useAppShortcuts(deps: AppShortcutsDeps): void {
   )
 
   useGuardedHotkeys(
-    'mod+1,mod+2,mod+3,mod+4,mod+5,mod+6,mod+7,mod+8,mod+9',
+    'mod+1,mod+2,mod+3,mod+4,mod+5,mod+6,mod+7,mod+8',
     (e) => {
       e.preventDefault()
       const num = parseInt(e.key, 10)
-      // visibleTabs[0] is the home tab; task tabs occupy visibleIndex 1..length-1.
-      // Chrome-style: mod+9 jumps to the LAST task tab regardless of count.
-      if (num === 9) {
-        if (visibleTabs.length > 1) setActiveTabIndex(toFullIndex(visibleTabs.length - 1))
-      } else if (num < visibleTabs.length) {
+      if (num < visibleTabs.length) {
         setActiveTabIndex(toFullIndex(num))
       }
     },
@@ -221,8 +217,10 @@ export function useAppShortcuts(deps: AppShortcutsDeps): void {
     (e) => {
       // macOS Cmd+Option+Right is "next word" in text fields; don't hijack.
       const el = e.target as HTMLElement
-      if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable) return
+      if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.tagName === 'SELECT') return
+      if (el.isContentEditable || el.getAttribute('role') === 'textbox') return
       if (el.closest?.('.cm-editor') || el.closest?.('.xterm')) return
+      if (el.closest?.('.milkdown') || el.closest?.('.ProseMirror')) return
       e.preventDefault()
       navigateTaskTabs(1)
     },
@@ -232,12 +230,25 @@ export function useAppShortcuts(deps: AppShortcutsDeps): void {
   useGuardedHotkeys(
     getKeys('prev-task-tab'),
     (e) => {
-      // macOS Cmd+Option+Left is "previous word" in text fields; don't hijack.
       const el = e.target as HTMLElement
-      if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable) return
+      if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.tagName === 'SELECT') return
+      if (el.isContentEditable || el.getAttribute('role') === 'textbox') return
       if (el.closest?.('.cm-editor') || el.closest?.('.xterm')) return
+      if (el.closest?.('.milkdown') || el.closest?.('.ProseMirror')) return
       e.preventDefault()
       navigateTaskTabs(-1)
+    },
+    { enableOnFormTags: true, enabled: !isRecording }
+  )
+
+  useGuardedHotkeys(
+    getKeys('last-task-tab'),
+    (e) => {
+      e.preventDefault()
+      if (visibleTabs.length > 1) {
+        useTabStore.getState().setActiveView('tabs')
+        setActiveTabIndex(toFullIndex(visibleTabs.length - 1))
+      }
     },
     { enableOnFormTags: true, enabled: !isRecording }
   )

--- a/packages/apps/app/src/renderer/src/app-shell/useAppShortcuts.ts
+++ b/packages/apps/app/src/renderer/src/app-shell/useAppShortcuts.ts
@@ -188,9 +188,7 @@ export function useAppShortcuts(deps: AppShortcutsDeps): void {
     (e) => {
       e.preventDefault()
       const num = parseInt(e.key, 10)
-      if (num < visibleTabs.length) {
-        setActiveTabIndex(toFullIndex(num))
-      }
+      if (num < visibleTabs.length) setActiveTabIndex(toFullIndex(num))
     },
     { enableOnFormTags: true, enabled: !isRecording }
   )

--- a/packages/apps/app/src/renderer/src/app-shell/useAppShortcuts.ts
+++ b/packages/apps/app/src/renderer/src/app-shell/useAppShortcuts.ts
@@ -184,7 +184,7 @@ export function useAppShortcuts(deps: AppShortcutsDeps): void {
   )
 
   useGuardedHotkeys(
-    'mod+1,mod+2,mod+3,mod+4,mod+5,mod+6,mod+7,mod+8',
+    'mod+1,mod+2,mod+3,mod+4,mod+5,mod+6,mod+7,mod+8,mod+9',
     (e) => {
       e.preventDefault()
       const num = parseInt(e.key, 10)
@@ -237,23 +237,6 @@ export function useAppShortcuts(deps: AppShortcutsDeps): void {
       if (el.closest?.('.milkdown') || el.closest?.('.ProseMirror')) return
       e.preventDefault()
       navigateTaskTabs(-1)
-    },
-    { enableOnFormTags: true, enabled: !isRecording }
-  )
-
-  useGuardedHotkeys(
-    getKeys('last-task-tab'),
-    (e) => {
-      const el = e.target as HTMLElement
-      if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.tagName === 'SELECT') return
-      if (el.isContentEditable || el.getAttribute('role') === 'textbox') return
-      if (el.closest?.('.cm-editor') || el.closest?.('.xterm')) return
-      if (el.closest?.('.milkdown') || el.closest?.('.ProseMirror')) return
-      e.preventDefault()
-      if (visibleTabs.length > 1) {
-        useTabStore.getState().setActiveView('tabs')
-        setActiveTabIndex(toFullIndex(visibleTabs.length - 1))
-      }
     },
     { enableOnFormTags: true, enabled: !isRecording }
   )

--- a/packages/apps/app/src/renderer/src/app-shell/useAppShortcuts.ts
+++ b/packages/apps/app/src/renderer/src/app-shell/useAppShortcuts.ts
@@ -244,6 +244,11 @@ export function useAppShortcuts(deps: AppShortcutsDeps): void {
   useGuardedHotkeys(
     getKeys('last-task-tab'),
     (e) => {
+      const el = e.target as HTMLElement
+      if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.tagName === 'SELECT') return
+      if (el.isContentEditable || el.getAttribute('role') === 'textbox') return
+      if (el.closest?.('.cm-editor') || el.closest?.('.xterm')) return
+      if (el.closest?.('.milkdown') || el.closest?.('.ProseMirror')) return
       e.preventDefault()
       if (visibleTabs.length > 1) {
         useTabStore.getState().setActiveView('tabs')

--- a/packages/apps/app/src/renderer/src/app-shell/useAppShortcuts.ts
+++ b/packages/apps/app/src/renderer/src/app-shell/useAppShortcuts.ts
@@ -188,7 +188,48 @@ export function useAppShortcuts(deps: AppShortcutsDeps): void {
     (e) => {
       e.preventDefault()
       const num = parseInt(e.key, 10)
-      if (num < visibleTabs.length) setActiveTabIndex(toFullIndex(num))
+      // visibleTabs[0] is the home tab; task tabs occupy visibleIndex 1..length-1.
+      // Chrome-style: mod+9 jumps to the LAST task tab regardless of count.
+      if (num === 9) {
+        if (visibleTabs.length > 1) setActiveTabIndex(toFullIndex(visibleTabs.length - 1))
+      } else if (num < visibleTabs.length) {
+        setActiveTabIndex(toFullIndex(num))
+      }
+    },
+    { enableOnFormTags: true, enabled: !isRecording }
+  )
+
+  // Cycle through open task tabs (skip the home tab), wrapping at the edges.
+  const navigateTaskTabs = useCallback(
+    (direction: 1 | -1) => {
+      // Task tabs live at visibleIndex 1..length-1 (visibleTabs[0] is home).
+      if (visibleTabs.length <= 1) return
+      const taskCount = visibleTabs.length - 1
+      const visibleIdx = toVisibleIndex(useTabStore.getState().activeTabIndex)
+      // Treat home / unknown position as "before the first task tab" so
+      // next jumps to first and prev jumps to last — same as Chrome.
+      const currentTaskPos = visibleIdx >= 1 ? visibleIdx - 1 : direction === 1 ? -1 : 0
+      const nextTaskPos = (currentTaskPos + direction + taskCount) % taskCount
+      useTabStore.getState().setActiveView('tabs')
+      setActiveTabIndex(toFullIndex(nextTaskPos + 1))
+    },
+    [visibleTabs.length, toFullIndex, toVisibleIndex, setActiveTabIndex]
+  )
+
+  useGuardedHotkeys(
+    getKeys('next-task-tab'),
+    (e) => {
+      e.preventDefault()
+      navigateTaskTabs(1)
+    },
+    { enableOnFormTags: true, enabled: !isRecording }
+  )
+
+  useGuardedHotkeys(
+    getKeys('prev-task-tab'),
+    (e) => {
+      e.preventDefault()
+      navigateTaskTabs(-1)
     },
     { enableOnFormTags: true, enabled: !isRecording }
   )

--- a/packages/apps/app/src/renderer/src/app-shell/useAppShortcuts.ts
+++ b/packages/apps/app/src/renderer/src/app-shell/useAppShortcuts.ts
@@ -219,6 +219,10 @@ export function useAppShortcuts(deps: AppShortcutsDeps): void {
   useGuardedHotkeys(
     getKeys('next-task-tab'),
     (e) => {
+      // macOS Cmd+Option+Right is "next word" in text fields; don't hijack.
+      const el = e.target as HTMLElement
+      if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable) return
+      if (el.closest?.('.cm-editor') || el.closest?.('.xterm')) return
       e.preventDefault()
       navigateTaskTabs(1)
     },
@@ -228,6 +232,10 @@ export function useAppShortcuts(deps: AppShortcutsDeps): void {
   useGuardedHotkeys(
     getKeys('prev-task-tab'),
     (e) => {
+      // macOS Cmd+Option+Left is "previous word" in text fields; don't hijack.
+      const el = e.target as HTMLElement
+      if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable) return
+      if (el.closest?.('.cm-editor') || el.closest?.('.xterm')) return
       e.preventDefault()
       navigateTaskTabs(-1)
     },

--- a/packages/apps/app/src/renderer/src/app-shell/useAppShortcuts.ts
+++ b/packages/apps/app/src/renderer/src/app-shell/useAppShortcuts.ts
@@ -95,7 +95,10 @@ export function useAppShortcuts(deps: AppShortcutsDeps): void {
   // ensures re-render when shortcuts change, so useHotkeys picks up new key strings.
   const getKeys = useCallback(
     (id: string): string => {
-      if (overrides[id]) return overrides[id]
+      // `id in overrides` distinguishes an explicit `null` (user disabled the
+      // shortcut) from a missing override (never customized → use default).
+      // A `null` override resolves to '' so nothing binds.
+      if (id in overrides) return overrides[id] ?? ''
       const def = shortcutDefinitions.find((d) => d.id === id)
       return def?.defaultKeys ?? ''
     },

--- a/packages/shared/shortcuts/src/definitions.ts
+++ b/packages/shared/shortcuts/src/definitions.ts
@@ -169,14 +169,6 @@ export const shortcutDefinitions: ShortcutDefinition[] = [
     customizable: true
   },
   {
-    id: 'last-task-tab',
-    label: 'Last Task Tab',
-    group: 'Tabs',
-    defaultKeys: 'mod+9',
-    scope: 'global',
-    customizable: true
-  },
-  {
     id: 'reopen-closed-tab',
     label: 'Reopen Closed Tab',
     group: 'Tabs',

--- a/packages/shared/shortcuts/src/definitions.ts
+++ b/packages/shared/shortcuts/src/definitions.ts
@@ -153,6 +153,22 @@ export const shortcutDefinitions: ShortcutDefinition[] = [
     scope: 'global'
   },
   {
+    id: 'next-task-tab',
+    label: 'Next Task Tab',
+    group: 'Tabs',
+    defaultKeys: 'mod+alt+arrowright',
+    scope: 'global',
+    customizable: false
+  },
+  {
+    id: 'prev-task-tab',
+    label: 'Previous Task Tab',
+    group: 'Tabs',
+    defaultKeys: 'mod+alt+arrowleft',
+    scope: 'global',
+    customizable: false
+  },
+  {
     id: 'reopen-closed-tab',
     label: 'Reopen Closed Tab',
     group: 'Tabs',

--- a/packages/shared/shortcuts/src/definitions.ts
+++ b/packages/shared/shortcuts/src/definitions.ts
@@ -158,7 +158,7 @@ export const shortcutDefinitions: ShortcutDefinition[] = [
     group: 'Tabs',
     defaultKeys: 'mod+alt+arrowright',
     scope: 'global',
-    customizable: false
+    customizable: true
   },
   {
     id: 'prev-task-tab',
@@ -166,7 +166,15 @@ export const shortcutDefinitions: ShortcutDefinition[] = [
     group: 'Tabs',
     defaultKeys: 'mod+alt+arrowleft',
     scope: 'global',
-    customizable: false
+    customizable: true
+  },
+  {
+    id: 'last-task-tab',
+    label: 'Last Task Tab',
+    group: 'Tabs',
+    defaultKeys: 'mod+9',
+    scope: 'global',
+    customizable: true
   },
   {
     id: 'reopen-closed-tab',


### PR DESCRIPTION
## Summary
- Add `Cmd+Option+Left` / `Cmd+Option+Right` to cycle through open task tabs in the top tab bar (wrap-around at edges, skips the home tab).
- Suppress the new cycle shortcuts inside text inputs (INPUT, TEXTAREA, SELECT, contentEditable, role="textbox", CodeMirror, xterm, Milkdown, ProseMirror) so they don't hijack the macOS "move by word" cursor behavior.

## Closes
Closes #98

## Notes on the diff
This branch also includes two small unrelated fixes that the typecheck on `main` currently fails without:
- `fix(transport): add missing resolve-task route stub` — registers a 501 stub for the missing module imported by `rest-api/index.ts`.
- `fix(app): add missing ws and @trpc/server deps for host-capability-server` — adds runtime deps already used by `packages/apps/app/src/main/host-capability-server.ts`.

Happy to split these out into a separate PR if preferred.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm --filter @slayzone/app test:e2e e2e/core/16-tab-management.spec.ts` — 11/11 pass, including 4 new cases for the shortcuts above.
- [x] Manual: with multiple task tabs open, `Cmd+Option+Left` and `Cmd+Option+Right` cycle through them and wrap at the edges.
- [x] Manual: shortcuts do NOT fire while typing in an input, textarea, contentEditable field, CodeMirror editor, xterm terminal, Milkdown/ProseMirror editor, or native `<select>`.
- [x] Manual: with only the home tab open, the cycle shortcuts are a no-op.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds task-tab cycling shortcuts for the app shell. The main changes are:

- New Cmd+Option+Left and Cmd+Option+Right bindings for previous and next task tab navigation.
- Wrap-around tab cycling that skips the home tab.
- Shortcut guards for text fields and editor surfaces.
- Shortcut definitions for the new customizable tab actions.
- E2E coverage for cycling, wrapping, home-tab behavior, and input suppression.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.
- No blocking issues found in the changed code.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/apps/app/src/renderer/src/app-shell/useAppShortcuts.ts | Adds explicit disabled-shortcut handling and task-tab cycling handlers with text/editor guards. |
| packages/shared/shortcuts/src/definitions.ts | Adds customizable shortcut definitions for next and previous task tab navigation. |
| packages/apps/app/e2e/core/16-tab-management.spec.ts | Adds tests for task-tab cycling, wrap-around behavior, home-tab behavior, and input suppression. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(shortcuts): respect explicit null ov..."](https://github.com/debuglebowski/slayzone/commit/6b8b3e095c02ccf95bbd40367ef408a4714a8b5b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39782745)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/slayzone/github/debuglebowski/slayzone/-/custom-context?memory=4d0a5da1-ee49-442f-ba49-d4a3dc97238d))
- Context used - AGENTS.md ([source](https://app.greptile.com/slayzone/github/debuglebowski/slayzone/-/custom-context?memory=ab121f38-2559-4d9f-973d-c13f20b07978))

<!-- /greptile_comment -->