### PR TITLE
fix: session resume for custom AI providers

### DIFF
--- a/packages/domains/task/src/server/ops/agent-sessions.ts
+++ b/packages/domains/task/src/server/ops/agent-sessions.ts
@@ -118,6 +118,25 @@ export function ownedSessionSql(resetAtExpr: string): string {
  */
 export const TURN_TRACKED_MODES: ReadonlySet<string> = new Set(['claude-code'])
 
+/**
+ * The AGENT a mode runs — the mode id itself for a built-in, or
+ * `terminal_modes.type` for a user-defined provider wrapping one.
+ *
+ * Turn-tracking is a property of the AGENT (whose hooks post the turn), never of
+ * the mode wrapping it. Testing the raw mode id classified every custom provider
+ * as "turns unobservable" and so marked its sessions resumability-proven at
+ * spawn — before any transcript exists. The next restart then resumed an id
+ * `--resume` cannot find, which fails, trips the healer, and RESETS the task:
+ * the user sees an empty chat and loses the conversation pointer.
+ */
+async function resolveTurnTrackedAgent(db: SlayzoneDb, mode: string): Promise<string> {
+  if (TURN_TRACKED_MODES.has(mode)) return mode
+  const row = await db.get<{ type?: string }>('SELECT type FROM terminal_modes WHERE id = ?', [
+    mode
+  ])
+  return row?.type ?? mode
+}
+
 const TTL_PENDING_MS = 10 * 60 * 1000 // explicit pre-minted expected id → wide window.
 const TTL_PENDING_NULL_EXPECTED_MS = 30 * 1000 // null-expected → tight window (temporal-proximity gate only).
 const FIND_PENDING_RETRY_MS = 100
@@ -617,7 +636,7 @@ export async function confirmSessionConversation(
   // until `markSessionFirstTurn`. Confirm is the right seam because it is the
   // first moment the REAL conversation id is known (a pre-mint can be wrong, and
   // providers that mint their own id have none until here).
-  if (usedResume || !TURN_TRACKED_MODES.has(row.mode)) {
+  if (usedResume || !TURN_TRACKED_MODES.has(await resolveTurnTrackedAgent(db, row.mode))) {
     await markSessionFirstTurn(db, args.observedConversationId)
   }
   return origin
@@ -645,10 +664,10 @@ export async function confirmSessionConversationByTaskMode(
 /** Mark a session's process exited. Lifecycle-only mutation (never touches a
  *  resume-critical value). */
 export async function markSessionDead(db: SlayzoneDb, sessionId: string): Promise<void> {
-  await db.run(
-    `UPDATE agent_sessions SET status = 'dead', ended_at = ? WHERE id = ?`,
-    [Date.now(), sessionId]
-  )
+  await db.run(`UPDATE agent_sessions SET status = 'dead', ended_at = ? WHERE id = ?`, [
+    Date.now(),
+    sessionId
+  ])
 }
 
 /**

--- a/packages/domains/terminal/src/server/mcp-env.test.ts
+++ b/packages/domains/terminal/src/server/mcp-env.test.ts
@@ -15,12 +15,7 @@
  *
  * Run with: npx tsx packages/domains/terminal/src/server/mcp-env.test.ts
  */
-import {
-  buildMcpEnv,
-  resolveRemoteMcpEnv,
-  AGENT_HOOK_PATH,
-  type RemoteMcpEnv
-} from './mcp-env'
+import { buildMcpEnv, resolveRemoteMcpEnv, AGENT_HOOK_PATH, type RemoteMcpEnv } from './mcp-env'
 
 let pass = 0
 function assert(cond: boolean, msg: string): void {
@@ -81,10 +76,7 @@ const REMOTE: RemoteMcpEnv = {
   )
   // The pre-rename name is NEVER written: notify.sh reads it only as a fallback so
   // an OLDER release channel's app can still feed a NEWER shared script.
-  assert(
-    !('SLAYZONE_HOOK_CONTEXT' in env),
-    'the retired SLAYZONE_HOOK_CONTEXT must NOT be written'
-  )
+  assert(!('SLAYZONE_HOOK_CONTEXT' in env), 'the retired SLAYZONE_HOOK_CONTEXT must NOT be written')
   const ctx = JSON.parse(env.SLAYZONE_AGENT_HOOK_CONTEXT!)
   assert(ctx.v === 1, `ctx envelope version must be 1, got ${ctx.v}`)
   assert(ctx.taskId === 'task-1', 'ctx carries taskId')
@@ -116,6 +108,56 @@ const REMOTE: RemoteMcpEnv = {
   assert(
     !('SLAYZONE_AGENT_HOOK_CONTEXT' in env),
     'non-hook mode must NOT set SLAYZONE_AGENT_HOOK_CONTEXT'
+  )
+}
+
+// A db that answers only the `terminal_modes.type` lookup — enough to resolve a
+// custom provider's agent. `mode` is the row's declared type, or undefined for
+// an unknown id (mirrors a deleted provider).
+function dbWithModeType(type: string | undefined): never {
+  return {
+    get: async (sql: string) =>
+      sql.includes('FROM terminal_modes') ? (type ? { type } : undefined) : undefined
+  } as never
+}
+
+// 1d. CUSTOM provider wrapping a hook-capable agent → hook-capable.
+//     Regression guard: gating on the MODE ID made every user-defined provider
+//     permanently hook-incapable, so notify.sh exited at its URL guard, the
+//     conversation was never confirmed, its ledger row stayed `pending-spawn`
+//     (not an honored origin) and each restart re-minted instead of resuming.
+{
+  const env = await buildMcpEnv(dbWithModeType('claude-code'), 'task-c', 'ccremote-t3b61' as never)
+  assert(
+    'SLAYZONE_AGENT_HOOK_URL' in env,
+    'custom provider wrapping claude-code must get the hook URL'
+  )
+  assert(
+    env.SLAYZONE_AGENT_ID === 'claude-code',
+    `SLAYZONE_AGENT_ID must be the AGENT, not the mode id — the server rejects unknown agents; got: ${env.SLAYZONE_AGENT_ID}`
+  )
+  const ctx = JSON.parse(env.SLAYZONE_AGENT_HOOK_CONTEXT!)
+  assert(ctx.agentId === 'claude-code', 'ctx.agentId is the wrapped agent')
+  assert(
+    ctx.mode === 'ccremote-t3b61',
+    `ctx.mode must carry the real mode so the ledger is keyed by it (not the built-in's row), got: ${ctx.mode}`
+  )
+}
+
+// 1e. Built-in mode → ctx carries NO `mode` key, so hook payloads for every
+//     existing provider stay byte-identical to before the custom-provider fix.
+{
+  const env = await buildMcpEnv(null, 'task-b', 'claude-code')
+  const ctx = JSON.parse(env.SLAYZONE_AGENT_HOOK_CONTEXT!)
+  assert(!('mode' in ctx), 'built-in ctx must omit `mode` (identical to pre-fix payload)')
+}
+
+// 1f. Custom provider whose declared type is NOT hook-capable → still no hook env.
+{
+  const env = await buildMcpEnv(dbWithModeType('some-shell'), 'task-d', 'my-shell-mode' as never)
+  assert(
+    !('SLAYZONE_AGENT_HOOK_CONTEXT' in env),
+    'custom provider wrapping a non-hook agent must NOT become hook-capable'
   )
 }
 
@@ -197,7 +239,14 @@ const REMOTE: RemoteMcpEnv = {
 
 // 6. Remote non-hook-capable → nothing hook-related, no hub env.
 {
-  const env = await buildMcpEnv(null, 'task-r3', 'some-unknown-mode' as never, undefined, undefined, REMOTE)
+  const env = await buildMcpEnv(
+    null,
+    'task-r3',
+    'some-unknown-mode' as never,
+    undefined,
+    undefined,
+    REMOTE
+  )
   assertNoHubEnv(env, 'non-hook remote')
   assert(!('SLAYZONE_AGENT_HOOK_URL' in env), 'no hook URL for non-hook remote mode')
   assert(!('SLAYZONE_AGENT_HOOK_CONTEXT' in env), 'no ctx blob for non-hook remote mode')
@@ -212,7 +261,11 @@ const REMOTE: RemoteMcpEnv = {
     called = true
     return REMOTE
   }
-  const r = await resolveRemoteMcpEnv(provider, { taskId: 't', runnerId: null, mode: 'claude-code' })
+  const r = await resolveRemoteMcpEnv(provider, {
+    taskId: 't',
+    runnerId: null,
+    mode: 'claude-code'
+  })
   assert(r === null, 'runnerId null must resolve to null')
   assert(called === false, 'provider must NOT be called for a local (null-runner) spawn')
 }
@@ -246,7 +299,11 @@ const REMOTE: RemoteMcpEnv = {
   const provider = () => {
     throw new Error('mint failed')
   }
-  const r = await resolveRemoteMcpEnv(provider, { taskId: 't', runnerId: 'r1', mode: 'claude-code' })
+  const r = await resolveRemoteMcpEnv(provider, {
+    taskId: 't',
+    runnerId: 'r1',
+    mode: 'claude-code'
+  })
   assert(r === null, 'a throwing provider must degrade to null')
 }
 

--- a/packages/domains/terminal/src/server/mcp-env.ts
+++ b/packages/domains/terminal/src/server/mcp-env.ts
@@ -154,7 +154,22 @@ export async function buildMcpEnv(
   if (resolvedProjectId) env.SLAYZONE_PROJECT_ID = resolvedProjectId
   if (sessionId) env.SLAYZONE_SESSION_ID = sessionId
 
-  const hookCapable = Boolean(mode && HOOK_SUPPORTED_AGENT_IDS.has(mode as AgentId))
+  // The AGENT this mode actually runs, which is not the same thing as the mode id.
+  // A built-in mode IS its agent id (`claude-code`), but a user-defined provider has
+  // its own slug (`ccremote-t3b61`) and declares the agent it wraps in
+  // `terminal_modes.type`. Gating on the mode id made every custom provider
+  // permanently hook-INcapable: it got no hook env, so notify.sh exited at its
+  // `[ -z "$SLAYZONE_AGENT_HOOK_URL" ]` guard, `confirmSessionConversation` never ran,
+  // its `task_conversations` row stayed `pending-spawn` (not an honored origin), and
+  // every restart re-minted a fresh session instead of resuming.
+  const agentId: string | undefined = !mode
+    ? undefined
+    : HOOK_SUPPORTED_AGENT_IDS.has(mode as AgentId)
+      ? mode
+      : (await db?.get<{ type?: string }>('SELECT type FROM terminal_modes WHERE id = ?', [mode]))
+          ?.type
+
+  const hookCapable = Boolean(agentId && HOOK_SUPPORTED_AGENT_IDS.has(agentId as AgentId))
 
   // On-disk anchor for EVERY spawn, hook-capable or not — this hub's own root,
   // which the `slay` CLI inside the child uses to find the DB (post-flattening
@@ -180,12 +195,20 @@ export async function buildMcpEnv(
   // channel fired the hook), so a future cross-release-channel clobber is
   // visible in Diagnostics.
   function setHookIdentity(): void {
-    env.SLAYZONE_AGENT_ID = mode as string
+    // AGENT id, never the mode id: the server rejects a hook whose agentId is not a
+    // known agent (`isAgentId` guard), and notify.sh documents this var as the agent.
+    env.SLAYZONE_AGENT_ID = agentId as string
     const ctx: Record<string, unknown> = {
       v: 1,
-      agentId: mode,
+      agentId,
       releaseChannel: getSlayzoneReleaseChannel()
     }
+    // The ledger and the PTY registry are keyed by MODE, which only equals the agent
+    // id for built-ins. Carry it separately so a custom provider's conversation is
+    // filed under its own mode instead of landing on the wrapped agent's built-in
+    // row (which would let the two providers resume into each other's sessions).
+    // Omitted when identical, so built-in hook payloads stay byte-identical.
+    if (mode && mode !== agentId) ctx.mode = mode
     if (taskId) ctx.taskId = taskId
     if (sessionId) ctx.slaySessionId = sessionId
     if (resolvedProjectId) ctx.projectId = resolvedProjectId

--- a/packages/shared/transport/src/server/http/rest-api/agent-hook.ts
+++ b/packages/shared/transport/src/server/http/rest-api/agent-hook.ts
@@ -324,6 +324,14 @@ const PayloadSchema = z.object({
  *  (state machine, prompt capture, conversation-id persist) read ONLY this. */
 interface ResolvedHook {
   agentId: HookAgentId
+  /**
+   * The terminal MODE this hook belongs to — what the conversation ledger and the
+   * PTY registry are keyed by. Equal to `agentId` for built-in modes, but a custom
+   * provider has its own id (`ccremote-t3b61`) while running a built-in agent, and
+   * only `agentId` may travel in the agent field (`isAgentId` rejects anything
+   * else). Falls back to `agentId` so legacy payloads and built-ins are unchanged.
+   */
+  mode: string
   hookEvent: string
   taskId?: string
   slaySessionId?: string
@@ -401,11 +409,15 @@ function resolveHookIdentity(body: z.infer<typeof PayloadSchema>): ResolvedHook 
 
   return {
     agentId: agentIdRaw,
+    // ctx-only (no legacy top-level equivalent) and absent when it equals the agent
+    // id, so every built-in and every pre-fix payload resolves exactly as before.
+    mode: typeof ctx?.mode === 'string' && ctx.mode ? ctx.mode : agentIdRaw,
     hookEvent,
     source: typeof effRaw?.source === 'string' ? effRaw.source : undefined,
     taskId: body.taskId ?? (typeof ctx?.taskId === 'string' ? ctx.taskId : undefined),
     slaySessionId:
-      body.slaySessionId ?? (typeof ctx?.slaySessionId === 'string' ? ctx.slaySessionId : undefined),
+      body.slaySessionId ??
+      (typeof ctx?.slaySessionId === 'string' ? ctx.slaySessionId : undefined),
     sessionId: cliSessionId,
     cwd: body.cwd ?? (typeof effRaw?.cwd === 'string' ? effRaw.cwd : undefined),
     raw: effRaw ?? body.raw,
@@ -449,7 +461,9 @@ function resolveHookIdentity(body: z.infer<typeof PayloadSchema>): ResolvedHook 
  */
 async function persistConversationId(
   deps: RestApiDeps,
-  agentId: string,
+  /** Terminal MODE, not the agent id — every lookup below keys the ledger by it
+   *  (`ResolvedHook.mode`). They differ for custom providers. */
+  mode: string,
   taskId: string,
   sessionId: string,
   /** `SessionStart.source` — see `ResolvedHook.source`. Only `'clear'` alters
@@ -480,7 +494,7 @@ async function persistConversationId(
     // but `compact` keeps the same id (already honored, nothing to fix) and
     // `fork`'s id semantics are unverified — left on the existing gate.
     if (source === 'clear') {
-      const outgoing = await getCurrentConversationId(deps.db, taskId, agentId)
+      const outgoing = await getCurrentConversationId(deps.db, taskId, mode)
       // Idempotence: a repeated SessionStart for a clear we already recorded
       // makes the new id the current one, so `outgoing === sessionId`. Nothing to
       // do — falling through would record a duplicate row every replay.
@@ -489,12 +503,12 @@ async function persistConversationId(
       // nothing to claim ownership OF, so skip the lookup and let the standard
       // gate handle it as an ordinary first spawn.
       const ownedSpawn = outgoing
-        ? await findOwnedSpawnForConversation(deps.db, taskId, agentId, outgoing)
+        ? await findOwnedSpawnForConversation(deps.db, taskId, mode, outgoing)
         : null
       if (ownedSpawn) {
         await recordConversation(deps.db, {
           taskId,
-          mode: agentId,
+          mode,
           conversationId: sessionId,
           origin: 'in-band-clear'
         })
@@ -512,7 +526,7 @@ async function persistConversationId(
     // honored on read). This closes the RC1 eager-persist clobber: a manual
     // `claude --resume <foreign>` inside a slay PTY can no longer bind the
     // foreign session to the task.
-    const pending = await findPendingSpawn(deps.db, taskId, agentId)
+    const pending = await findPendingSpawn(deps.db, taskId, mode)
     // No pending → no spawn-intent record: definitely foreign.
     // Pending w/ expectedSessionId === null → fresh PTY spawn where slay did
     // NOT pre-mint a UUID; accept the first observed id as fresh (temporal-
@@ -530,7 +544,7 @@ async function persistConversationId(
           : 'foreign-observed'
     await recordConversation(deps.db, {
       taskId,
-      mode: agentId,
+      mode,
       conversationId: sessionId,
       origin
     })
@@ -631,7 +645,11 @@ export async function processAgentHook(
   // carry only the former, and this must cover pooled and task-spawned agents
   // through one path. Fire-and-forget: a DB hiccup must never block the ack, and
   // the next turn re-attempts.
-  if (hook.sessionId && TURN_PROOF_EVENTS.has(hook.hookEvent) && !firstTurnMarked.has(hook.sessionId)) {
+  if (
+    hook.sessionId &&
+    TURN_PROOF_EVENTS.has(hook.hookEvent) &&
+    !firstTurnMarked.has(hook.sessionId)
+  ) {
     const provenId = hook.sessionId
     firstTurnMarked.add(provenId)
     void markSessionFirstTurn(deps.db, provenId).catch(() => {
@@ -651,9 +669,9 @@ export async function processAgentHook(
       // Awaited: a single indexed SELECT + UPDATE on local SQLite is sub-ms,
       // and the capture event is low-frequency (repeats short-circuit in the
       // helper) — keeping it deterministic beats a fire-and-forget race.
-      await persistConversationId(deps, hook.agentId, hook.taskId, cliSessionId, hook.source)
+      await persistConversationId(deps, hook.mode, hook.taskId, cliSessionId, hook.source)
       // Mirror onto the live PTY session for the idle-close gate.
-      const ptySessionId = bridge?.findSession(hook.taskId, hook.agentId as TerminalMode)
+      const ptySessionId = bridge?.findSession(hook.taskId, hook.mode as TerminalMode)
       if (ptySessionId) bridge?.noteConversationId?.(ptySessionId, cliSessionId)
     } else if (!hook.taskId && hook.slaySessionId && cliSessionId) {
       // Pre-warmed POOLED agent: no task yet, so capture the conversation
@@ -676,7 +694,7 @@ export async function processAgentHook(
   // for hook-driven agents (replaces adapter output detection / bullet-glyph
   // regex). gemini/opencode still rely on adapter detection.
   if (bridge && isHookDrivenMode(hook.agentId) && resolvedTaskId) {
-    const mode = hook.agentId as TerminalMode
+    const mode = hook.mode as TerminalMode
     const sessionId = bridge.findSession(resolvedTaskId, mode)
     if (sessionId) {
       const newState = hookToTerminalState(hook.agentId, hook.hookEvent, hook.raw)


### PR DESCRIPTION
# fix: session resume for custom AI providers

A user-defined provider could never resume a session — every restart started an empty chat, while built-in providers resumed fine.

## Root cause

Two places ask a question about the **agent** but test the **mode id**. A built-in mode *is* its agent id (`claude-code`); a user-defined provider has its own slug and declares the agent it wraps in `terminal_modes.type`.

**1. `hookCapable` (`mcp-env.ts`)** — gated on the mode id, so a custom provider was structurally hook-incapable. It received no hook env at all, so `notify.sh` exited at its `[ -z "$SLAYZONE_AGENT_HOOK_URL" ]` guard, `confirmSessionConversation` never ran, the row stayed `pending-spawn` (not an honored origin), and `resolveSpawnConversation` therefore found no id — `initialCommand` won on every spawn.

**2. `TURN_TRACKED_MODES` (`agent-sessions.ts`)** — same confusion. A custom provider counted as "turns unobservable", so its sessions were marked resumability-proven *at spawn*, before any transcript existed. The next restart resumed an id `--resume` cannot find, which fails, trips the healer, and **resets the task** — losing the conversation pointer.

The second matters as much as the first: fixing only #1 promotes the provider straight into #2, making resume *worse* rather than better.

## Changes

- Resolve the agent from `terminal_modes.type` (falling back to the mode id, so built-ins are untouched) and gate on that in both places.
- `SLAYZONE_AGENT_ID` must stay a real agent id — the hook endpoint rejects anything else via `isAgentId` — so the mode travels separately as `ctx.mode`, and the ledger/PTY lookups key off it. Without this a custom provider's conversation is filed under the wrapped agent's built-in row, and the two can resume into each other's sessions.
- `ctx.mode` is omitted when it equals the agent id, so built-in hook payloads stay **byte-identical** and legacy flat payloads resolve unchanged.

## Evidence

Diagnosed against a real custom provider (mode `ccremote-t3b61`, `type = claude-code`, wrapping Claude Code in tmux):

- ledger showed `ccremote-t3b61 | pending-spawn | 5` and **zero** honored rows, against `claude-code | slay-spawned-fresh | 16` + `slay-spawned-resume | 5`
- all 22 live tmux sessions had been started with `--session-id`; **not one** with `--resume`
- verified separately that `claude --session-id X` then `claude --resume X` works, so the CLI was not at fault

After the fix, on a live build: spawns record `usedResume: true`, conversations self-confirm, zero resets.

## Verification

- `mcp-env.test.ts` — 60 → **66 checks**. New cases: a custom provider wrapping a hook-capable agent gets the hook env and carries `ctx.mode`; a built-in's ctx **omits** `mode` (payload unchanged); a custom provider wrapping a non-hook agent stays incapable.
- `agent-hook.test.ts` — 71 pass. `spawn-conversation.test.ts` — 14 pass.
- Typecheck clean on `packages/domains/terminal`, `packages/domains/task`, `packages/shared/transport`.

## Known gap

`agent-sessions.test.ts` could not be executed in my checkout — it fails to resolve `better-sqlite3` under the repo's test runner, and fails identically on an unmodified tree, so it is pre-existing rather than caused by this change. That means **commit 2 has no executed regression test**. Happy to add one if you can point me at how that suite is meant to run in your environment.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR fixes session resumption for custom AI providers by resolving behavior from the wrapped agent type while retaining the custom mode as the ledger and PTY key.
- Resolves hook capability and turn tracking through `terminal_modes.type`.
- Carries custom mode identity separately in hook context while preserving built-in payloads.
- Uses the resolved mode for conversation persistence and live PTY state updates.
- Adds coverage for hook-capable and non-hook-capable custom providers.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issue established.

The changed paths consistently distinguish wrapped agent identity from terminal mode identity, preserve built-in behavior, and route custom-provider session confirmation, persistence, and PTY updates through the intended mode.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/domains/task/src/server/ops/agent-sessions.ts | Resolves the wrapped agent before deciding whether confirmation itself proves session resumability. |
| packages/domains/terminal/src/server/mcp-env.ts | Enables hooks for custom providers wrapping supported agents and sends agent and mode identities separately. |
| packages/shared/transport/src/server/http/rest-api/agent-hook.ts | Resolves optional mode context and consistently uses it for conversation-ledger and PTY lookups. |
| packages/domains/terminal/src/server/mcp-env.test.ts | Adds regression checks for custom-provider hook capability, identity propagation, and built-in compatibility. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Spawn as Custom provider spawn
    participant DB as terminal_modes
    participant Env as buildMcpEnv
    participant Agent as Wrapped agent
    participant Hook as Agent hook endpoint
    participant Ledger as Conversation ledger
    participant PTY as PTY registry

    Spawn->>DB: Resolve mode.type
    DB-->>Env: Wrapped agent ID
    Env->>Agent: Hook URL + agentId + ctx.mode
    Agent->>Hook: Session/turn hook
    Hook->>Ledger: Persist using custom mode
    Hook->>PTY: Find/update using custom mode
    Ledger-->>Spawn: Conversation becomes resumable
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(task): key turn-tracking on the agen..."](https://github.com/debuglebowski/slayzone/commit/8a0debda03133c278cb336834ade5def4d758711) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51279356)</sub>

<!-- /greptile_comment -->