### PR TITLE
feat: explode mode layout control — repack, minimize, swap

### DIFF
--- a/packages/apps/app/src/renderer/src/App.tsx
+++ b/packages/apps/app/src/renderer/src/App.tsx
@@ -9,7 +9,7 @@ import React, {
   useTransition
 } from 'react'
 import { initShortcuts } from './shortcut-init'
-import { AlertTriangle, BookOpen } from 'lucide-react'
+import { AlertTriangle, BookOpen, GripVertical, Minimize2 } from 'lucide-react'
 import { useMutation, useQuery } from '@tanstack/react-query'
 import {
   useTRPC,
@@ -109,6 +109,15 @@ import type {
   ProjectIntegrationOnboardingProvider,
   ContextManagerSection
 } from './app-shell'
+import {
+  computeExplodeLayout,
+  ExplodeMinimizedTray,
+  type ExplodeCellRect
+} from '@slayzone/app-shell'
+
+/** Custom DnD mime so an explode-cell drag is distinguishable from dragged text
+ *  or files, which terminals and editors must keep handling themselves. */
+const EXPLODE_DRAG_TYPE = 'application/x-slayzone-explode-cell'
 
 function App(): React.JSX.Element {
   performance.mark('sz:app:render')
@@ -328,9 +337,37 @@ function App(): React.JSX.Element {
   )
   const activeAgentTaskIds = useActiveSessionTaskIds()
 
-  // Explode mode (multi-task grid) — owns toggle, focused cell, grid ref + width
-  const { explodeMode, setExplodeMode, focusedExplodeTaskId, explodeGridRef, explodeGridWidth } =
-    useExplodeMode(openTaskIds, tabs, activeTabIndex)
+  // Explode mode (multi-task grid) — owns toggle, focused cell, grid ref + size,
+  // and the user's arrangement (order + which terminals are parked in the tray).
+  const {
+    explodeMode,
+    setExplodeMode,
+    focusedExplodeTaskId,
+    explodeGridRef,
+    explodeGridWidth,
+    explodeGridHeight,
+    explodeVisibleTaskIds,
+    explodeMinimizedTaskIds,
+    minimizeExplodeTask,
+    restoreExplodeTask,
+    restoreAllExplodeTasks,
+    swapExplodeTasks
+  } = useExplodeMode(openTaskIds, tabs, activeTabIndex)
+
+  // Explicit pixel rects per cell (see explodeLayout for why not CSS grid tracks).
+  // `p-1` on the container is the outer frame, so subtract it from the usable box.
+  const explodeRects = useMemo(() => {
+    if (!explodeMode) return new Map<string, ExplodeCellRect>()
+    const PAD = 4
+    const { cells } = computeExplodeLayout({
+      taskIds: explodeVisibleTaskIds,
+      width: Math.max(0, explodeGridWidth - PAD * 2),
+      height: Math.max(0, explodeGridHeight - PAD * 2),
+      gap: 4,
+      minCellWidth: 480
+    })
+    return new Map(cells.map((c) => [c.taskId, c]))
+  }, [explodeMode, explodeVisibleTaskIds, explodeGridWidth, explodeGridHeight])
 
   // Tab lifecycle (extracted — manages sync, cleanup, cache eviction, page tracking)
   useTabLifecycle({
@@ -1482,6 +1519,14 @@ function App(): React.JSX.Element {
                               {visibleTaskCount} {visibleTaskCount === 1 ? 'task' : 'tasks'}
                             </div>
                           )}
+                          {explodeMode && explodeMinimizedTaskIds.length > 0 && (
+                            <ExplodeMinimizedTray
+                              taskIds={explodeMinimizedTaskIds}
+                              titleFor={(id) => tasksMap.get(id)?.title ?? 'Untitled'}
+                              onRestore={restoreExplodeTask}
+                              onRestoreAll={restoreAllExplodeTasks}
+                            />
+                          )}
                         </>
                       ) : undefined
                     }
@@ -1536,216 +1581,297 @@ function App(): React.JSX.Element {
                     </div>
                   ) : null}
                   <div className="flex-1 min-h-0 flex overflow-hidden">
-                  <div
-                    ref={explodeGridRef}
-                    className={cn(
-                      'flex-1 min-w-0 min-h-0 rounded-lg overflow-hidden relative',
-                      explodeMode ? 'grid gap-1 p-1' : ''
-                    )}
-                    style={{
-                      ...(explodeMode
-                        ? (() => {
-                            const MIN_CELL_W = 480
-                            const widthCols =
-                              explodeGridWidth > 0
-                                ? Math.max(1, Math.floor(explodeGridWidth / MIN_CELL_W))
-                                : Math.ceil(Math.sqrt(visibleTaskCount))
-                            const cols = Math.max(1, Math.min(widthCols, visibleTaskCount))
-                            const rows = Math.ceil(visibleTaskCount / cols)
-                            return {
-                              gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))`,
-                              gridTemplateRows: `repeat(${rows}, minmax(0, 1fr))`
+                    <div
+                      ref={explodeGridRef}
+                      className={cn(
+                        'flex-1 min-w-0 min-h-0 rounded-lg overflow-hidden relative',
+                        explodeMode ? 'p-1' : ''
+                      )}
+                      // CAPTURE phase, on the grid rather than per cell. `Terminal.tsx`
+                      // attaches a `dragover` listener that calls stopPropagation()
+                      // unconditionally (it owns file-drop-to-paste-path), so a bubbling
+                      // handler on the cell never fires once the pointer is over terminal
+                      // content — which is most of a cell, and ALL of a full-height one.
+                      // Capture runs before that listener, so a swap lands wherever the
+                      // user drops. Gated on our own mime so file/text drags still fall
+                      // through to the terminal untouched.
+                      onDragOverCapture={
+                        explodeMode
+                          ? (e) => {
+                              if (!e.dataTransfer.types.includes(EXPLODE_DRAG_TYPE)) return
+                              e.preventDefault()
+                              e.dataTransfer.dropEffect = 'move'
                             }
-                          })()
-                        : undefined)
-                    }}
-                  >
-                    {tabs.map((tab, i) => {
-                      const isVisible = toVisibleIndex(i) >= 0
-                      if (explodeMode && (tab.type !== 'task' || !isVisible)) return null
-                      // Inactive tabs hide via `invisible` (visibility:hidden). CSS does not
-                      // interpolate `visibility`, so a descendant carrying a `transition` (e.g.
-                      // Button's `transition-all`) stays fully painted for the whole transition
-                      // duration before snapping off — that was the "Turn into task" button
-                      // lingering on tab switch. Hidden tabs are inert, so we also kill their
-                      // descendant transitions (`[&_*]:transition-none!` below) → the hide is
-                      // instant for every element, not just ones without a transition.
-                      const isViewActive = activeView === 'tabs' && i === deferredActiveTabIndex
-                      const isExplodeFocused =
-                        explodeMode && tab.type === 'task' && focusedExplodeTaskId === tab.taskId
-                      return (
-                        <div
-                          key={tab.type === 'home' ? 'home' : tab.taskId}
-                          data-explode-task-id={
-                            explodeMode && tab.type === 'task' ? tab.taskId : undefined
-                          }
-                          className={
-                            explodeMode
-                              ? cn(
-                                  'rounded overflow-hidden border min-h-0 relative',
-                                  isExplodeFocused
-                                    ? 'border-primary/60 ring-2 ring-primary/40'
-                                    : 'border-border'
-                                )
-                              : `absolute inset-0 ${!isViewActive ? 'invisible [&_*]:transition-none!' : 'z-10'}`
-                          }
-                          inert={!explodeMode && !isViewActive ? true : undefined}
-                        >
-                          {/* Multi-hub: scope each tab's content to the hub that
+                          : undefined
+                      }
+                      onDropCapture={
+                        explodeMode
+                          ? (e) => {
+                              if (!e.dataTransfer.types.includes(EXPLODE_DRAG_TYPE)) return
+                              const from = e.dataTransfer.getData(EXPLODE_DRAG_TYPE)
+                              // In capture phase `e.target` is still the deepest node (the
+                              // terminal), so walk up to whichever cell owns it.
+                              const cell = (e.target as HTMLElement | null)?.closest?.(
+                                '[data-explode-task-id]'
+                              )
+                              const to = cell?.getAttribute('data-explode-task-id')
+                              e.preventDefault()
+                              e.stopPropagation()
+                              if (from && to && from !== to) swapExplodeTasks(from, to)
+                            }
+                          : undefined
+                      }
+                    >
+                      {tabs.map((tab, i) => {
+                        const isVisible = toVisibleIndex(i) >= 0
+                        if (explodeMode && (tab.type !== 'task' || !isVisible)) return null
+                        // Inactive tabs hide via `invisible` (visibility:hidden). CSS does not
+                        // interpolate `visibility`, so a descendant carrying a `transition` (e.g.
+                        // Button's `transition-all`) stays fully painted for the whole transition
+                        // duration before snapping off — that was the "Turn into task" button
+                        // lingering on tab switch. Hidden tabs are inert, so we also kill their
+                        // descendant transitions (`[&_*]:transition-none!` below) → the hide is
+                        // instant for every element, not just ones without a transition.
+                        const isViewActive = activeView === 'tabs' && i === deferredActiveTabIndex
+                        const isExplodeFocused =
+                          explodeMode && tab.type === 'task' && focusedExplodeTaskId === tab.taskId
+                        // A minimized cell has no rect: it is parked in the header tray.
+                        // It stays MOUNTED and merely hidden — unmounting would tear down
+                        // its xterm and lose the scrollback the user minimized to keep.
+                        const explodeRect =
+                          explodeMode && tab.type === 'task'
+                            ? explodeRects.get(tab.taskId)
+                            : undefined
+                        const isExplodeMinimized =
+                          explodeMode && tab.type === 'task' && !explodeRect
+                        return (
+                          <div
+                            key={tab.type === 'home' ? 'home' : tab.taskId}
+                            data-explode-task-id={
+                              explodeMode && tab.type === 'task' ? tab.taskId : undefined
+                            }
+                            className={
+                              explodeMode
+                                ? isExplodeMinimized
+                                  ? 'absolute inset-0 invisible [&_*]:transition-none!'
+                                  : cn(
+                                      'group absolute rounded overflow-hidden border min-h-0',
+                                      isExplodeFocused
+                                        ? 'border-primary/60 ring-2 ring-primary/40 z-10'
+                                        : 'border-border'
+                                    )
+                                : `absolute inset-0 ${!isViewActive ? 'invisible [&_*]:transition-none!' : 'z-10'}`
+                            }
+                            style={
+                              explodeRect
+                                ? {
+                                    left: explodeRect.left + 4,
+                                    top: explodeRect.top + 4,
+                                    width: explodeRect.width,
+                                    height: explodeRect.height
+                                  }
+                                : undefined
+                            }
+                            inert={
+                              (!explodeMode && !isViewActive) || isExplodeMinimized
+                                ? true
+                                : undefined
+                            }
+                          >
+                            {explodeRect && tab.type === 'task' ? (
+                              // Hover-revealed cell chrome. Absolutely positioned over the
+                              // content rather than inset above it, so showing it never
+                              // resizes the terminal underneath (an xterm reflow on hover
+                              // would reflow the user's output).
+                              <div className="absolute top-0 right-0 z-20 flex items-center gap-0.5 rounded-bl bg-surface-2/90 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
+                                <button
+                                  type="button"
+                                  draggable
+                                  onDragStart={(e) => {
+                                    e.dataTransfer.setData(EXPLODE_DRAG_TYPE, tab.taskId)
+                                    e.dataTransfer.effectAllowed = 'move'
+                                  }}
+                                  title="Drag onto another terminal to swap places"
+                                  aria-label="Drag to swap position"
+                                  data-testid="explode-drag-handle"
+                                  className="cursor-grab p-1 text-muted-foreground hover:text-foreground active:cursor-grabbing"
+                                >
+                                  <GripVertical className="size-3.5" />
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() => minimizeExplodeTask(tab.taskId)}
+                                  title="Minimize to the header tray (keeps running)"
+                                  aria-label="Minimize terminal"
+                                  data-testid="explode-minimize"
+                                  className="p-1 text-muted-foreground hover:text-foreground"
+                                >
+                                  <Minimize2 className="size-3.5" />
+                                </button>
+                              </div>
+                            ) : null}
+                            {/* Multi-hub: scope each tab's content to the hub that
                               owns it, so ambient useTRPC() (TaskDetailPage/
                               HomeDetail + the hub-keyed taskDetailCache) resolves
                               to the right hub. Single-hub → HubScope(default) is
                               the same client the app is already wrapped in. */}
-                          <HubScope
-                            hubId={
-                              tab.type === 'task'
-                                ? (hubIdByTask.get(tab.taskId) ?? defaultHubId)
-                                : selectedProjectHubId
-                            }
-                          >
-                          {tab.type === 'home' ? (
-                            <HomeDetail
-                              durationLocked={durationLocked}
-                              selectedProject={selectedProject}
-                              selectedProjectId={selectedProjectId}
-                              projects={projects}
-                              updateProject={updateProject}
-                              updateTask={updateTask}
-                              projectNameInputRef={projectNameInputRef}
-                              projectNameValue={projectNameValue}
-                              setProjectNameValue={setProjectNameValue}
-                              handleProjectNameSave={handleProjectNameSave}
-                              handleProjectNameKeyDown={handleProjectNameKeyDown}
-                              projectPathMissing={projectPathMissing}
-                              handleFixProjectPath={handleFixProjectPath}
-                              filter={filter}
-                              setFilter={setFilter}
-                              projectTags={projectTags}
-                              homePanel={homePanel}
-                              homePanelConfig={homePanelConfig}
-                              isHomePanelEnabled={isHomePanelEnabled}
-                              panelSizes={panelSizes}
-                              updatePanelSizes={updatePanelSizes}
-                              resetPanelSize={resetPanelSize}
-                              testsPanelEnabled={testsPanelEnabled}
-                              testGroupBy={testGroupBy}
-                              homeResolvedRepo={homeResolvedRepo}
-                              homeDetectedRepos={homeDetectedRepos}
-                              homeSelectedProject={homeSelectedProject}
-                              handleHomeRepoChange={handleHomeRepoChange}
-                              isViewActive={isViewActive}
-                              isHomeTabActive={tabs[activeTabIndex]?.type === 'home'}
-                              tasks={tasks}
-                              displayTasks={displayTasks}
-                              taskTags={taskTags}
-                              blockedTaskIds={blockedTaskIds}
-                              handleTaskMove={handleTaskMove}
-                              handleTaskBulkMove={handleTaskBulkMove}
-                              reorderTasks={reorderTasks}
-                              handleTaskClick={handleTaskClick}
-                              handleTaskTagsChange={handleTaskTagsChange}
-                              contextMenuUpdate={contextMenuUpdate}
-                              bulkContextMenuUpdate={bulkContextMenuUpdate}
-                              clearBlockers={clearBlockers}
-                              archiveTask={archiveTask}
-                              deleteTask={deleteTask}
-                              bulkDelete={bulkDelete}
-                              archiveTasks={archiveTasks}
-                              activeAgentTaskIds={activeAgentTaskIds}
-                              shutdownAgentForTask={shutdownAgentForTask}
-                              globalAgentPanelState={globalAgentPanelState}
-                              agentStatusState={agentStatusState}
-                              openProjectSettings={openProjectSettings}
-                              panelGitShortcut={panelGitShortcut}
-                              panelEditorShortcut={panelEditorShortcut}
-                              panelProcessesShortcut={panelProcessesShortcut}
-                              panelTestsShortcut={panelTestsShortcut}
-                              panelAutomationsShortcut={panelAutomationsShortcut}
-                            />
-                          ) : (
-                            <Suspense fallback={<TaskShell />}>
-                              <div className={explodeMode ? 'absolute inset-0' : 'h-full'}>
-                                <TaskDetailDataLoader
-                                  taskId={tab.taskId}
-                                  task={tasksMap.get(tab.taskId) ?? null}
-                                  project={
-                                    projectsMap.get(tasksMap.get(tab.taskId)?.project_id ?? '') ??
-                                    null
-                                  }
-                                  isActive={explodeMode || isViewActive}
-                                  hasShortcutFocus={
-                                    explodeMode ? focusedExplodeTaskId === tab.taskId : isViewActive
-                                  }
-                                  compact={explodeMode}
-                                  zenMode={zenMode}
-                                  onBack={goBack}
-                                  onTaskUpdated={updateTask}
-                                  onArchiveTask={archiveTask}
-                                  onDeleteTask={deleteTask}
-                                  onNavigateToTask={openTask}
-                                  onConvertTask={handleConvertTask}
-                                  onCloseTab={closeTabByTaskId}
-                                  settingsRevision={settingsRevision}
-                                  terminalFocusRequestId={terminalFocusRequests[tab.taskId] ?? 0}
-                                  onTerminalFocusRequestHandled={handleTerminalFocusRequestHandled}
-                                  isSidePanelResizing={isSidePanelResizing}
+                            <HubScope
+                              hubId={
+                                tab.type === 'task'
+                                  ? (hubIdByTask.get(tab.taskId) ?? defaultHubId)
+                                  : selectedProjectHubId
+                              }
+                            >
+                              {tab.type === 'home' ? (
+                                <HomeDetail
+                                  durationLocked={durationLocked}
+                                  selectedProject={selectedProject}
+                                  selectedProjectId={selectedProjectId}
+                                  projects={projects}
+                                  updateProject={updateProject}
+                                  updateTask={updateTask}
+                                  projectNameInputRef={projectNameInputRef}
+                                  projectNameValue={projectNameValue}
+                                  setProjectNameValue={setProjectNameValue}
+                                  handleProjectNameSave={handleProjectNameSave}
+                                  handleProjectNameKeyDown={handleProjectNameKeyDown}
+                                  projectPathMissing={projectPathMissing}
+                                  handleFixProjectPath={handleFixProjectPath}
+                                  filter={filter}
+                                  setFilter={setFilter}
+                                  projectTags={projectTags}
+                                  homePanel={homePanel}
+                                  homePanelConfig={homePanelConfig}
+                                  isHomePanelEnabled={isHomePanelEnabled}
+                                  panelSizes={panelSizes}
+                                  updatePanelSizes={updatePanelSizes}
+                                  resetPanelSize={resetPanelSize}
+                                  testsPanelEnabled={testsPanelEnabled}
+                                  testGroupBy={testGroupBy}
+                                  homeResolvedRepo={homeResolvedRepo}
+                                  homeDetectedRepos={homeDetectedRepos}
+                                  homeSelectedProject={homeSelectedProject}
+                                  handleHomeRepoChange={handleHomeRepoChange}
+                                  isViewActive={isViewActive}
+                                  isHomeTabActive={tabs[activeTabIndex]?.type === 'home'}
+                                  tasks={tasks}
+                                  displayTasks={displayTasks}
+                                  taskTags={taskTags}
+                                  blockedTaskIds={blockedTaskIds}
+                                  handleTaskMove={handleTaskMove}
+                                  handleTaskBulkMove={handleTaskBulkMove}
+                                  reorderTasks={reorderTasks}
+                                  handleTaskClick={handleTaskClick}
+                                  handleTaskTagsChange={handleTaskTagsChange}
+                                  contextMenuUpdate={contextMenuUpdate}
+                                  bulkContextMenuUpdate={bulkContextMenuUpdate}
+                                  clearBlockers={clearBlockers}
+                                  archiveTask={archiveTask}
+                                  deleteTask={deleteTask}
+                                  bulkDelete={bulkDelete}
+                                  archiveTasks={archiveTasks}
+                                  activeAgentTaskIds={activeAgentTaskIds}
+                                  shutdownAgentForTask={shutdownAgentForTask}
+                                  globalAgentPanelState={globalAgentPanelState}
+                                  agentStatusState={agentStatusState}
+                                  openProjectSettings={openProjectSettings}
+                                  panelGitShortcut={panelGitShortcut}
+                                  panelEditorShortcut={panelEditorShortcut}
+                                  panelProcessesShortcut={panelProcessesShortcut}
+                                  panelTestsShortcut={panelTestsShortcut}
+                                  panelAutomationsShortcut={panelAutomationsShortcut}
                                 />
-                              </div>
-                            </Suspense>
-                          )}
-                          </HubScope>
+                              ) : (
+                                <Suspense fallback={<TaskShell />}>
+                                  <div className={explodeMode ? 'absolute inset-0' : 'h-full'}>
+                                    <TaskDetailDataLoader
+                                      taskId={tab.taskId}
+                                      task={tasksMap.get(tab.taskId) ?? null}
+                                      project={
+                                        projectsMap.get(
+                                          tasksMap.get(tab.taskId)?.project_id ?? ''
+                                        ) ?? null
+                                      }
+                                      isActive={explodeMode || isViewActive}
+                                      hasShortcutFocus={
+                                        explodeMode
+                                          ? focusedExplodeTaskId === tab.taskId
+                                          : isViewActive
+                                      }
+                                      compact={explodeMode}
+                                      zenMode={zenMode}
+                                      onBack={goBack}
+                                      onTaskUpdated={updateTask}
+                                      onArchiveTask={archiveTask}
+                                      onDeleteTask={deleteTask}
+                                      onNavigateToTask={openTask}
+                                      onConvertTask={handleConvertTask}
+                                      onCloseTab={closeTabByTaskId}
+                                      settingsRevision={settingsRevision}
+                                      terminalFocusRequestId={
+                                        terminalFocusRequests[tab.taskId] ?? 0
+                                      }
+                                      onTerminalFocusRequestHandled={
+                                        handleTerminalFocusRequestHandled
+                                      }
+                                      isSidePanelResizing={isSidePanelResizing}
+                                    />
+                                  </div>
+                                </Suspense>
+                              )}
+                            </HubScope>
+                          </div>
+                        )
+                      })}
+                      {activeView === 'leaderboard' && (
+                        <div className="absolute inset-0 z-20">
+                          <Suspense fallback={null}>
+                            <LeaderboardPage auth={leaderboardAuth} />
+                          </Suspense>
                         </div>
-                      )
-                    })}
-                    {activeView === 'leaderboard' && (
-                      <div className="absolute inset-0 z-20">
-                        <Suspense fallback={null}>
-                          <LeaderboardPage auth={leaderboardAuth} />
-                        </Suspense>
-                      </div>
-                    )}
-                    {activeView === 'usage-analytics' && (
-                      <div className="absolute inset-0 z-20">
-                        <Suspense fallback={null}>
-                          <UsageAnalyticsPage onTaskClick={openTask} />
-                        </Suspense>
-                      </div>
-                    )}
-                    {activeView === 'context' && (
-                      <div className="absolute inset-0 z-20">
-                        <Suspense fallback={null}>
-                          <ContextManagerPage
-                            selectedProjectId={selectedProjectId}
-                            projectPath={projects.find((p) => p.id === selectedProjectId)?.path}
-                            projectName={projects.find((p) => p.id === selectedProjectId)?.name}
-                            onBack={() => useTabStore.getState().setActiveView('tabs')}
-                          />
-                        </Suspense>
-                      </div>
-                    )}
-                  </div>
+                      )}
+                      {activeView === 'usage-analytics' && (
+                        <div className="absolute inset-0 z-20">
+                          <Suspense fallback={null}>
+                            <UsageAnalyticsPage onTaskClick={openTask} />
+                          </Suspense>
+                        </div>
+                      )}
+                      {activeView === 'context' && (
+                        <div className="absolute inset-0 z-20">
+                          <Suspense fallback={null}>
+                            <ContextManagerPage
+                              selectedProjectId={selectedProjectId}
+                              projectPath={projects.find((p) => p.id === selectedProjectId)?.path}
+                              projectName={projects.find((p) => p.id === selectedProjectId)?.name}
+                              onBack={() => useTabStore.getState().setActiveView('tabs')}
+                            />
+                          </Suspense>
+                        </div>
+                      )}
+                    </div>
 
-                  <AppSidePanels
-                    agentSessionId={agentSessionId}
-                    globalAgentPanelMounted={globalAgentPanelMountedRef.current}
-                    hideSidebarPanel={hideSidebarPanel}
-                    globalAgentPanelState={globalAgentPanelState}
-                    setGlobalAgentPanelState={setGlobalAgentPanelState}
-                    isSidePanelResizing={isSidePanelResizing}
-                    setIsSidePanelResizing={setIsSidePanelResizing}
-                    projects={projects}
-                    selectedProjectId={selectedProjectId}
-                    agentMode={agentMode}
-                    handleAgentNewSession={handleAgentNewSession}
-                    handleAgentModeChange={handleAgentModeChange}
-                    floatingState={floatingGlobalAgentPanelState.kind}
-                    agentStatusState={agentStatusState}
-                    setAgentStatusState={setAgentStatusState}
-                    idleTasks={idleTasks}
-                    openTask={openTask}
-                    handleDismissIdle={handleDismissIdle}
-                    columnsByProjectId={columnsByProjectId}
-                  />
+                    <AppSidePanels
+                      agentSessionId={agentSessionId}
+                      globalAgentPanelMounted={globalAgentPanelMountedRef.current}
+                      hideSidebarPanel={hideSidebarPanel}
+                      globalAgentPanelState={globalAgentPanelState}
+                      setGlobalAgentPanelState={setGlobalAgentPanelState}
+                      isSidePanelResizing={isSidePanelResizing}
+                      setIsSidePanelResizing={setIsSidePanelResizing}
+                      projects={projects}
+                      selectedProjectId={selectedProjectId}
+                      agentMode={agentMode}
+                      handleAgentNewSession={handleAgentNewSession}
+                      handleAgentModeChange={handleAgentModeChange}
+                      floatingState={floatingGlobalAgentPanelState.kind}
+                      agentStatusState={agentStatusState}
+                      setAgentStatusState={setAgentStatusState}
+                      idleTasks={idleTasks}
+                      openTask={openTask}
+                      handleDismissIdle={handleDismissIdle}
+                      columnsByProjectId={columnsByProjectId}
+                    />
                   </div>
                 </div>
               </div>

--- a/packages/domains/app-shell/src/client/ExplodeMinimizedTray.tsx
+++ b/packages/domains/app-shell/src/client/ExplodeMinimizedTray.tsx
@@ -1,0 +1,76 @@
+import { ChevronDown, Minimize2 } from 'lucide-react'
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from '@slayzone/ui'
+
+export interface ExplodeMinimizedTrayProps {
+  /** Minimized task ids, in the user's arranged order. */
+  taskIds: readonly string[]
+  titleFor: (taskId: string) => string
+  onRestore: (taskId: string) => void
+  onRestoreAll: () => void
+}
+
+/**
+ * Header parking bay for explode-mode terminals the user minimized.
+ *
+ * Lives beside the "N tasks" label because explode mode is the one tab layout
+ * with spare header room. A minimized terminal is NOT closed or unmounted — it
+ * keeps running with its scrollback intact and simply stops being given grid
+ * space, so the remaining cells repack over it. Picking one here puts it straight
+ * back into the mix.
+ *
+ * Renders nothing when the bay is empty (the caller gates on length, and this
+ * guards again) so explode mode looks untouched until the feature is used.
+ */
+export function ExplodeMinimizedTray({
+  taskIds,
+  titleFor,
+  onRestore,
+  onRestoreAll
+}: ExplodeMinimizedTrayProps): React.JSX.Element | null {
+  if (taskIds.length === 0) return null
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="ml-2 h-6 gap-1 px-2 text-xs text-muted-foreground flex-shrink-0"
+          aria-label={`${taskIds.length} minimized ${taskIds.length === 1 ? 'terminal' : 'terminals'}`}
+          data-testid="explode-minimized-tray"
+        >
+          <Minimize2 className="size-3" />
+          {taskIds.length}
+          <ChevronDown className="size-3 opacity-60" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="min-w-56">
+        {taskIds.map((taskId) => (
+          <DropdownMenuItem
+            key={taskId}
+            onSelect={() => onRestore(taskId)}
+            className="text-xs"
+            data-testid="explode-restore-item"
+          >
+            <span className="truncate">{titleFor(taskId)}</span>
+          </DropdownMenuItem>
+        ))}
+        {taskIds.length > 1 && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={onRestoreAll} className="text-xs font-medium">
+              Restore all
+            </DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/packages/domains/app-shell/src/client/explodeLayout.test.ts
+++ b/packages/domains/app-shell/src/client/explodeLayout.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Unit tests for the explode-mode layout engine.
+ *
+ * Run with: npx tsx packages/domains/app-shell/src/client/explodeLayout.test.ts
+ */
+import {
+  computeExplodeLayout,
+  explodeColumnCount,
+  explodeColumnSizes,
+  reconcileExplodeOrder,
+  swapExplodeOrder
+} from './explodeLayout'
+
+let pass = 0
+function assert(cond: boolean, msg: string): void {
+  if (!cond) {
+    console.error('FAIL:', msg)
+    process.exit(1)
+  }
+  pass++
+}
+function eq(a: number, b: number, msg: string): void {
+  assert(Math.abs(a - b) < 0.001, `${msg} (got ${a}, want ${b})`)
+}
+
+const BASE = { gap: 4, minCellWidth: 480 }
+const ids = (n: number): string[] => Array.from({ length: n }, (_, i) => `t${i + 1}`)
+
+// ── column count ────────────────────────────────────────────────────────────
+{
+  eq(explodeColumnCount(1000, 4, 480), 2, '1000px fits 2 columns at 480 min')
+  eq(explodeColumnCount(1500, 4, 480), 3, '1500px fits 3')
+  eq(explodeColumnCount(400, 4, 480), 1, 'below one min width still yields 1 column')
+  // Never more columns than items — extra columns would be the empty cells this fixes.
+  eq(explodeColumnCount(5000, 2, 480), 2, 'columns capped by item count')
+  eq(explodeColumnCount(1000, 0, 480), 0, 'no items → no columns')
+}
+
+// ── column sizes: earlier columns take the remainder ────────────────────────
+{
+  assert(JSON.stringify(explodeColumnSizes(3, 2)) === '[2,1]', '3/2 → [2,1]')
+  assert(JSON.stringify(explodeColumnSizes(5, 2)) === '[3,2]', '5/2 → [3,2]')
+  assert(JSON.stringify(explodeColumnSizes(5, 3)) === '[2,2,1]', '5/3 → [2,2,1]')
+  assert(JSON.stringify(explodeColumnSizes(4, 2)) === '[2,2]', '4/2 → [2,2] (already even)')
+  assert(JSON.stringify(explodeColumnSizes(1, 1)) === '[1]', '1/1 → [1]')
+}
+
+// ── THE REGRESSION THIS FIXES: 3 cells, 2 columns ───────────────────────────
+// Old behaviour was a 2x2 grid with a dead bottom-right cell and t3 at half
+// height. The odd one out must now own its column at FULL height.
+{
+  const { cols, cells } = computeExplodeLayout({
+    ...BASE,
+    taskIds: ids(3),
+    width: 1000,
+    height: 600
+  })
+  eq(cols, 2, '3 items in 1000px → 2 columns')
+  const [t1, t2, t3] = cells
+  eq(t1.height, (600 - 4) / 2, 't1 is half height (shares column 1)')
+  eq(t2.height, (600 - 4) / 2, 't2 is half height')
+  eq(t3.height, 600, 't3 takes the FULL height of its own column')
+  eq(t3.top, 0, 't3 starts at the top')
+  assert(t1.col === 0 && t2.col === 0 && t3.col === 1, 'column-major placement')
+  // No dead space: every column is filled top to bottom.
+  eq(t1.top + t1.height + 4, t2.top, 't1 and t2 are flush with one gap')
+  eq(t2.top + t2.height, 600, 'column 1 reaches the bottom exactly')
+}
+
+// ── widths tile the container exactly ───────────────────────────────────────
+{
+  const { cells } = computeExplodeLayout({ ...BASE, taskIds: ids(3), width: 1000, height: 600 })
+  const colW = (1000 - 4) / 2
+  eq(cells[0].width, colW, 'column width accounts for the gutter')
+  eq(cells[2].left, colW + 4, 'second column starts after the gutter')
+  eq(cells[2].left + cells[2].width, 1000, 'right edge lands exactly on the container')
+}
+
+// ── minimize = leave the grid entirely (parked in the header tray) ──────────
+// The caller drops minimized ids from `taskIds`; the survivors must repack as if
+// the terminal was never there, rather than a strip continuing to hold a row.
+{
+  const { cols, cells } = computeExplodeLayout({
+    ...BASE,
+    taskIds: ['t1', 't3'], // t2 minimized out of a 3-task set
+    width: 1000,
+    height: 600
+  })
+  eq(cols, 2, '2 remaining tasks → 2 columns')
+  eq(cells[0].height, 600, 'each survivor takes a full column')
+  eq(cells[1].height, 600, 'no leftover strip holding a row')
+  eq(cells[1].left + cells[1].width, 1000, 'survivors still tile the full width')
+}
+
+// Minimizing down to one leaves a single full-bleed cell.
+{
+  const { cols, cells } = computeExplodeLayout({
+    ...BASE,
+    taskIds: ['t2'],
+    width: 1000,
+    height: 600
+  })
+  eq(cols, 1, 'one visible task → one column')
+  eq(cells[0].width, 1000, 'full width')
+  eq(cells[0].height, 600, 'full height')
+}
+
+// Minimizing ALL of them is legal and yields an empty grid, not broken geometry.
+{
+  const { cols, cells } = computeExplodeLayout({ ...BASE, taskIds: [], width: 1000, height: 600 })
+  assert(cols === 0 && cells.length === 0, 'everything minimized → empty grid')
+}
+
+// ── single column (narrow window) stacks everything ─────────────────────────
+{
+  const { cols, cells } = computeExplodeLayout({
+    ...BASE,
+    taskIds: ids(3),
+    width: 400,
+    height: 600
+  })
+  eq(cols, 1, 'narrow window collapses to one column')
+  eq(cells[0].width, 400, 'full width')
+  eq(cells[2].top + cells[2].height, 600, 'stack reaches the bottom')
+}
+
+// ── rects are whole pixels and still tile exactly ───────────────────────────
+// Awkward sizes that do not divide evenly: xterm derives its row count from the
+// measured height, so a fractional one can oscillate between N and N+1 rows on
+// sub-pixel jitter — each flip a real fit(), SIGWINCH and atlas re-raster.
+{
+  const { cells } = computeExplodeLayout({ ...BASE, taskIds: ids(5), width: 1001, height: 601 })
+  for (const c of cells) {
+    assert(Number.isInteger(c.left), `left is a whole pixel (${c.left})`)
+    assert(Number.isInteger(c.top), `top is a whole pixel (${c.top})`)
+    assert(Number.isInteger(c.width), `width is a whole pixel (${c.width})`)
+    assert(Number.isInteger(c.height), `height is a whole pixel (${c.height})`)
+  }
+  // Rounding EDGES rather than sizes means neighbours still meet exactly.
+  const col0 = cells.filter((c) => c.col === 0)
+  const col1 = cells.filter((c) => c.col === 1)
+  eq(col0[0].left + col0[0].width + 4, col1[0].left, 'columns meet across the gutter, no drift')
+  eq(col0[col0.length - 1].top + col0[col0.length - 1].height, 601, 'column 0 ends on the edge')
+  eq(col1[col1.length - 1].top + col1[col1.length - 1].height, 601, 'column 1 ends on the edge')
+}
+
+// ── empty / degenerate ──────────────────────────────────────────────────────
+{
+  const empty = computeExplodeLayout({ ...BASE, taskIds: [], width: 1000, height: 600 })
+  assert(empty.cells.length === 0 && empty.cols === 0, 'no items → empty layout')
+  const zero = computeExplodeLayout({ ...BASE, taskIds: ids(2), width: 0, height: 0 })
+  assert(zero.cells.length === 2, 'zero-size container still yields one rect per item')
+}
+
+// ── swap: exchanges exactly two positions, never cascades ───────────────────
+{
+  const order = ['a', 'b', 'c', 'd']
+  assert(JSON.stringify(swapExplodeOrder(order, 'a', 'd')) === '["d","b","c","a"]', 'ends swap')
+  assert(JSON.stringify(swapExplodeOrder(order, 'b', 'c')) === '["a","c","b","d"]', 'middle swap')
+  assert(
+    JSON.stringify(swapExplodeOrder(order, 'a', 'a')) === '["a","b","c","d"]',
+    'self is a no-op'
+  )
+  assert(
+    JSON.stringify(swapExplodeOrder(order, 'a', 'zz')) === '["a","b","c","d"]',
+    'unknown id is a no-op, not a crash'
+  )
+  assert(JSON.stringify(order) === '["a","b","c","d"]', 'input array is not mutated')
+}
+
+// ── reconcile: keep arrangement, drop closed, append new ────────────────────
+{
+  assert(
+    JSON.stringify(reconcileExplodeOrder(['c', 'a'], ['a', 'b', 'c'])) === '["c","a","b"]',
+    'stored order preserved; newly opened task appended'
+  )
+  assert(
+    JSON.stringify(reconcileExplodeOrder(['c', 'a'], ['a'])) === '["a"]',
+    'closed tasks dropped'
+  )
+  assert(
+    JSON.stringify(reconcileExplodeOrder([], ['a', 'b'])) === '["a","b"]',
+    'no stored order → open order'
+  )
+}
+
+console.log(`OK — explodeLayout ${pass} checks passed`)

--- a/packages/domains/app-shell/src/client/explodeLayout.test.ts
+++ b/packages/domains/app-shell/src/client/explodeLayout.test.ts
@@ -184,4 +184,31 @@ const ids = (n: number): string[] => Array.from({ length: n }, (_, i) => `t${i +
   )
 }
 
+// ── duplicates in a stored order must collapse ──────────────────────────────
+// A duplicate id gets laid out twice while the renderer draws each task once, so
+// the grid sizes itself for the larger count and one rect is orphaned as dead
+// space — the exact defect this layout exists to remove.
+{
+  assert(
+    JSON.stringify(reconcileExplodeOrder(['a', 'a', 'b'], ['a', 'b'])) === '["a","b"]',
+    'duplicate id collapses to one, first position wins'
+  )
+  assert(
+    JSON.stringify(reconcileExplodeOrder(['b', 'a', 'b'], ['a', 'b'])) === '["b","a"]',
+    'first occurrence sets the position, later ones are dropped'
+  )
+  assert(
+    JSON.stringify(reconcileExplodeOrder(['a', 'a'], ['a', 'b'])) === '["a","b"]',
+    'dedupe still appends the tasks that were never in the stored order'
+  )
+
+  // End to end: every allocated rect must belong to a distinct task, or the
+  // renderer's id→rect map silently drops one and leaves a hole.
+  const reconciled = reconcileExplodeOrder(['a', 'a', 'b'], ['a', 'b'])
+  const { cells } = computeExplodeLayout({ ...BASE, taskIds: reconciled, width: 1000, height: 600 })
+  const unique = new Set(cells.map((c) => c.taskId))
+  assert(cells.length === unique.size, 'no two rects share a task id')
+  eq(cells.length, 2, 'grid is sized for the real task count, not the padded one')
+}
+
 console.log(`OK — explodeLayout ${pass} checks passed`)

--- a/packages/domains/app-shell/src/client/explodeLayout.ts
+++ b/packages/domains/app-shell/src/client/explodeLayout.ts
@@ -1,0 +1,164 @@
+/**
+ * Explode-mode layout engine.
+ *
+ * Pure geometry so the packing rules are unit-testable without a DOM, and so the
+ * renderer stays a dumb `style={rect}` application. Returns absolute pixel rects
+ * rather than CSS grid tracks for three reasons:
+ *
+ *  1. The cells are ONE flat `tabs.map` shared by explode and normal mode (normal
+ *     mode already positions them `absolute inset-0`). Wrapping them in per-column
+ *     elements for explode mode would change the React tree between modes and
+ *     REMOUNT every terminal — xterm would lose its scrollback on each toggle.
+ *  2. Drag-to-swap animates cleanly when every cell already has an explicit rect.
+ *
+ * MINIMIZE is deliberately NOT modelled here. A minimized terminal is parked in the
+ * header tray and leaves the grid entirely, so the caller simply omits its id from
+ * `taskIds` and the remaining cells repack to fill the space. Collapsing it to an
+ * in-grid strip instead would keep spending a row on a terminal the user just said
+ * they were done looking at.
+ *
+ * PACKING: column-major, no dead cells. Items are split across columns as evenly
+ * as possible with earlier columns taking the remainder, so an odd item out lands
+ * alone in a later column and takes that column's FULL height — rather than
+ * sitting half-height beside an empty cell, which is the layout this replaces.
+ *
+ *   3 items / 2 cols → [2, 1]   col2's single item is full height
+ *   5 items / 2 cols → [3, 2]
+ *   5 items / 3 cols → [2, 2, 1]
+ *   4 items / 2 cols → [2, 2]   already even, unchanged
+ */
+
+export interface ExplodeCellRect {
+  taskId: string
+  left: number
+  top: number
+  width: number
+  height: number
+  /** Column index, for drag hit-testing and debugging. */
+  col: number
+}
+
+export interface ExplodeLayout {
+  cols: number
+  cells: ExplodeCellRect[]
+}
+
+export interface ExplodeLayoutInput {
+  /** Task ids in display order — already reordered by any user drag, and with
+   *  minimized ids already removed (they live in the header tray, not the grid). */
+  taskIds: readonly string[]
+  width: number
+  height: number
+  /** Gutter between cells, both axes. */
+  gap: number
+  /** Narrowest a cell may get before dropping a column. */
+  minCellWidth: number
+}
+
+/**
+ * How many columns fit, capped by the item count so N items never produce more
+ * than N columns (which would leave trailing empties — the very thing this fixes).
+ */
+export function explodeColumnCount(width: number, count: number, minCellWidth: number): number {
+  if (count <= 0) return 0
+  if (width <= 0) return Math.max(1, Math.min(count, Math.ceil(Math.sqrt(count))))
+  const fit = Math.max(1, Math.floor(width / minCellWidth))
+  return Math.max(1, Math.min(fit, count))
+}
+
+/**
+ * Items per column, column-major, earlier columns taking the remainder.
+ * Never returns a zero-sized column: `cols` is always <= `count`.
+ */
+export function explodeColumnSizes(count: number, cols: number): number[] {
+  if (count <= 0 || cols <= 0) return []
+  const base = Math.floor(count / cols)
+  const extra = count % cols
+  return Array.from({ length: cols }, (_, i) => base + (i < extra ? 1 : 0))
+}
+
+export function computeExplodeLayout(input: ExplodeLayoutInput): ExplodeLayout {
+  const { taskIds, width, height, gap, minCellWidth } = input
+  const count = taskIds.length
+  if (count === 0) return { cols: 0, cells: [] }
+
+  const cols = explodeColumnCount(width, count, minCellWidth)
+  const sizes = explodeColumnSizes(count, cols)
+
+  const totalGapX = gap * (cols - 1)
+  const colWidth = Math.max(0, (width - totalGapX) / cols)
+
+  const cells: ExplodeCellRect[] = []
+  let cursor = 0
+
+  for (let col = 0; col < cols; col++) {
+    const size = sizes[col]
+    const ids = taskIds.slice(cursor, cursor + size)
+    cursor += size
+
+    const left = col * (colWidth + gap)
+    const totalGapY = gap * (size - 1)
+    // Clamp at 0 so a container smaller than its own gutters yields degenerate
+    // rects rather than negative ones.
+    const cellHeight = Math.max(0, (height - totalGapY) / size)
+
+    // Snap to whole pixels by rounding EDGES, not sizes: adjacent cells then share
+    // an exact boundary instead of drifting apart by a rounding error each.
+    //
+    // Fractional heights are not cosmetic here. xterm derives its row count from
+    // the measured container, so a height landing on a row boundary (e.g. 298.4px
+    // at a 17px line height) can flip between N and N+1 rows as the observer
+    // reports sub-pixel jitter — each flip is a real fit(), a SIGWINCH to the pty
+    // and a WebGL atlas re-raster. Integer rects make the row count stable.
+    const leftPx = Math.round(left)
+    const rightPx = Math.round(left + colWidth)
+
+    let top = 0
+    for (const taskId of ids) {
+      const topPx = Math.round(top)
+      const bottomPx = Math.round(top + cellHeight)
+      cells.push({
+        taskId,
+        left: leftPx,
+        top: topPx,
+        width: rightPx - leftPx,
+        height: bottomPx - topPx,
+        col
+      })
+      top += cellHeight + gap
+    }
+  }
+
+  return { cols, cells }
+}
+
+/**
+ * Swap two ids in the display order. Swap, not splice-reorder: dragging cell A
+ * onto cell B should exchange exactly those two positions and leave every other
+ * cell where the user last put it. A splice would cascade-shift the tail, which
+ * reads as "everything moved" when the user asked for one trade.
+ */
+export function swapExplodeOrder(order: readonly string[], a: string, b: string): string[] {
+  const next = [...order]
+  const ia = next.indexOf(a)
+  const ib = next.indexOf(b)
+  if (ia === -1 || ib === -1 || ia === ib) return next
+  next[ia] = b
+  next[ib] = a
+  return next
+}
+
+/**
+ * Reconcile a persisted order against the tabs that are actually open: keep the
+ * user's arrangement, drop closed tasks, append newly-opened ones. Without this a
+ * stored order silently hides a task that was opened after it was saved.
+ */
+export function reconcileExplodeOrder(
+  order: readonly string[],
+  openTaskIds: readonly string[]
+): string[] {
+  const open = new Set(openTaskIds)
+  const kept = order.filter((id) => open.has(id))
+  const known = new Set(kept)
+  return [...kept, ...openTaskIds.filter((id) => !known.has(id))]
+}

--- a/packages/domains/app-shell/src/client/explodeLayout.ts
+++ b/packages/domains/app-shell/src/client/explodeLayout.ts
@@ -152,13 +152,26 @@ export function swapExplodeOrder(order: readonly string[], a: string, b: string)
  * Reconcile a persisted order against the tabs that are actually open: keep the
  * user's arrangement, drop closed tasks, append newly-opened ones. Without this a
  * stored order silently hides a task that was opened after it was saved.
+ *
+ * Guarantees each open id appears EXACTLY ONCE. A duplicate would otherwise be
+ * laid out twice while the renderer draws each task once — the grid sizes itself
+ * for the larger count and one rect is left orphaned as dead space, which is the
+ * exact defect this layout exists to remove. Deduping here rather than at the
+ * persistence boundary because this is the single choke point every read passes
+ * through, so the invariant holds for any source of a bad order, not just a
+ * hand-edited settings blob.
  */
 export function reconcileExplodeOrder(
   order: readonly string[],
   openTaskIds: readonly string[]
 ): string[] {
   const open = new Set(openTaskIds)
-  const kept = order.filter((id) => open.has(id))
-  const known = new Set(kept)
-  return [...kept, ...openTaskIds.filter((id) => !known.has(id))]
+  const seen = new Set<string>()
+  const kept: string[] = []
+  for (const id of order) {
+    if (!open.has(id) || seen.has(id)) continue
+    seen.add(id)
+    kept.push(id)
+  }
+  return [...kept, ...openTaskIds.filter((id) => !seen.has(id))]
 }

--- a/packages/domains/app-shell/src/client/index.ts
+++ b/packages/domains/app-shell/src/client/index.ts
@@ -2,4 +2,17 @@
 // the Chromium fork. Holds the header action bar + the explode-mode hook so
 // neither shell reimplements them.
 export { useExplodeMode, type ExplodeModeApi } from './useExplodeMode'
+export {
+  ExplodeMinimizedTray,
+  type ExplodeMinimizedTrayProps
+} from './ExplodeMinimizedTray'
+export {
+  computeExplodeLayout,
+  explodeColumnCount,
+  explodeColumnSizes,
+  swapExplodeOrder,
+  reconcileExplodeOrder,
+  type ExplodeCellRect,
+  type ExplodeLayout
+} from './explodeLayout'
 export { AppHeaderActions } from './AppHeaderActions'

--- a/packages/domains/app-shell/src/client/useExplodeMode.ts
+++ b/packages/domains/app-shell/src/client/useExplodeMode.ts
@@ -1,5 +1,7 @@
 import {
+  useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
   type Dispatch,
@@ -7,6 +9,7 @@ import {
   type SetStateAction
 } from 'react'
 import { useTabStore } from '@slayzone/settings'
+import { reconcileExplodeOrder, swapExplodeOrder } from './explodeLayout'
 
 type Tabs = ReturnType<typeof useTabStore.getState>['tabs']
 
@@ -16,10 +19,22 @@ export interface ExplodeModeApi {
   focusedExplodeTaskId: string | null
   explodeGridRef: RefObject<HTMLDivElement | null>
   explodeGridWidth: number
+  explodeGridHeight: number
+  /** Open task ids in user-arranged order, minimized ones removed — exactly what
+   *  the grid lays out. */
+  explodeVisibleTaskIds: string[]
+  /** Parked in the header tray; still open tabs, just not given grid space. */
+  explodeMinimizedTaskIds: string[]
+  minimizeExplodeTask: (taskId: string) => void
+  restoreExplodeTask: (taskId: string) => void
+  restoreAllExplodeTasks: () => void
+  /** Exchange two cells' positions (drag-to-swap). */
+  swapExplodeTasks: (a: string, b: string) => void
 }
 
 // Explode mode = multi-task grid. Owns its toggle, the keyboard-focused cell,
-// the grid ref, and the responsive grid width. Effects keep all three in sync
+// the grid ref, the responsive grid size, and the user's arrangement (order +
+// which terminals are parked in the header tray). Effects keep all of it in sync
 // with the open task tabs.
 export function useExplodeMode(
   openTaskIds: string[],
@@ -32,25 +47,95 @@ export function useExplodeMode(
   const [focusedExplodeTaskId, setFocusedExplodeTaskId] = useState<string | null>(null)
   const explodeGridRef = useRef<HTMLDivElement | null>(null)
   const [explodeGridWidth, setExplodeGridWidth] = useState(0)
+  const [explodeGridHeight, setExplodeGridHeight] = useState(0)
+  // User arrangement, persisted in the tab store's `viewState` slice so a renderer
+  // reload or restart keeps the layout the user built. May lag the open tabs (a
+  // task opened or closed since the last drag), so every read goes through
+  // reconcile rather than trusting it.
+  const order = useTabStore((s) => s.explodeOrder)
+  const minimizedList = useTabStore((s) => s.explodeMinimized)
+  const setExplodeArrangement = useTabStore((s) => s.setExplodeArrangement)
+  const minimized = useMemo<ReadonlySet<string>>(() => new Set(minimizedList), [minimizedList])
 
   // Auto-disable explode mode when fewer than 2 task tabs
   useEffect(() => {
     if (openTaskIds.length < 2) setExplodeMode(false)
   }, [openTaskIds.length])
 
-  // Seed / clear focused explode cell on mode toggle; keep valid as tabs change
+  // Drop arrangement state for tasks that are no longer open, so a closed-then-
+  // reopened task comes back visible instead of invisibly stuck in the tray.
+  useEffect(() => {
+    const open = new Set(openTaskIds)
+    const pruned = minimizedList.filter((id) => open.has(id))
+    if (pruned.length !== minimizedList.length) {
+      setExplodeArrangement({ minimized: pruned })
+    }
+  }, [openTaskIds, minimizedList, setExplodeArrangement])
+
+  const orderedTaskIds = useMemo(
+    () => reconcileExplodeOrder(order, openTaskIds),
+    [order, openTaskIds]
+  )
+
+  const explodeVisibleTaskIds = useMemo(
+    () => orderedTaskIds.filter((id) => !minimized.has(id)),
+    [orderedTaskIds, minimized]
+  )
+
+  const explodeMinimizedTaskIds = useMemo(
+    () => orderedTaskIds.filter((id) => minimized.has(id)),
+    [orderedTaskIds, minimized]
+  )
+
+  const minimizeExplodeTask = useCallback(
+    (taskId: string) => {
+      if (minimizedList.includes(taskId)) return
+      setExplodeArrangement({ minimized: [...minimizedList, taskId] })
+    },
+    [minimizedList, setExplodeArrangement]
+  )
+
+  const restoreExplodeTask = useCallback(
+    (taskId: string) => {
+      if (!minimizedList.includes(taskId)) return
+      setExplodeArrangement({ minimized: minimizedList.filter((id) => id !== taskId) })
+    },
+    [minimizedList, setExplodeArrangement]
+  )
+
+  const restoreAllExplodeTasks = useCallback(() => {
+    if (minimizedList.length === 0) return
+    setExplodeArrangement({ minimized: [] })
+  }, [minimizedList.length, setExplodeArrangement])
+
+  // Persist the RECONCILED order, not the stale stored one: a swap against an
+  // order that predates a newly-opened task would otherwise drop that task.
+  const swapExplodeTasks = useCallback(
+    (a: string, b: string) => {
+      setExplodeArrangement({
+        order: swapExplodeOrder(reconcileExplodeOrder(order, openTaskIds), a, b)
+      })
+    },
+    [order, openTaskIds, setExplodeArrangement]
+  )
+
+  // Seed / clear focused explode cell on mode toggle; keep valid as tabs change.
+  // A minimized task must never hold focus — its cell is gone, so shortcuts would
+  // route to a terminal the user cannot see.
   useEffect(() => {
     if (!explodeMode) {
       setFocusedExplodeTaskId(null)
       return
     }
     setFocusedExplodeTaskId((prev) => {
-      if (prev && openTaskIds.includes(prev)) return prev
+      if (prev && explodeVisibleTaskIds.includes(prev)) return prev
       const activeTab = tabs[activeTabIndex]
-      if (activeTab?.type === 'task') return activeTab.taskId
-      return openTaskIds[0] ?? null
+      if (activeTab?.type === 'task' && explodeVisibleTaskIds.includes(activeTab.taskId)) {
+        return activeTab.taskId
+      }
+      return explodeVisibleTaskIds[0] ?? null
     })
-  }, [explodeMode, openTaskIds, activeTabIndex, tabs])
+  }, [explodeMode, explodeVisibleTaskIds, activeTabIndex, tabs])
 
   // Delegated focusin: bubble from xterm / editor / browser → grid cell; resolve task id.
   useEffect(() => {
@@ -67,19 +152,42 @@ export function useExplodeMode(
     return () => grid.removeEventListener('focusin', handleFocusIn)
   }, [explodeMode])
 
-  // Track grid width so explode mode can pack more columns as the window grows.
+  // Track grid size so explode mode can pack more columns as the window grows.
+  // Height matters too now: cells are positioned as explicit rects rather than
+  // `1fr` grid tracks, so the layout cannot fall back on the container stretching.
   useEffect(() => {
     if (!explodeMode) return
     const grid = explodeGridRef.current
     if (!grid) return
     setExplodeGridWidth(grid.clientWidth)
+    setExplodeGridHeight(grid.clientHeight)
     const ro = new ResizeObserver((entries) => {
-      const w = entries[0]?.contentRect.width ?? 0
-      setExplodeGridWidth(w)
+      const rect = entries[0]?.contentRect
+      // Round and bail on no-change. `contentRect` reports sub-pixel values, so a
+      // raw set re-rendered the whole app tree — and re-laid out every terminal —
+      // on jitter far below one pixel. Same-value setState is a bail-out in React,
+      // so this collapses that churn to real size changes only.
+      const w = Math.round(rect?.width ?? 0)
+      const h = Math.round(rect?.height ?? 0)
+      setExplodeGridWidth((prev) => (prev === w ? prev : w))
+      setExplodeGridHeight((prev) => (prev === h ? prev : h))
     })
     ro.observe(grid)
     return () => ro.disconnect()
   }, [explodeMode])
 
-  return { explodeMode, setExplodeMode, focusedExplodeTaskId, explodeGridRef, explodeGridWidth }
+  return {
+    explodeMode,
+    setExplodeMode,
+    focusedExplodeTaskId,
+    explodeGridRef,
+    explodeGridWidth,
+    explodeGridHeight,
+    explodeVisibleTaskIds,
+    explodeMinimizedTaskIds,
+    minimizeExplodeTask,
+    restoreExplodeTask,
+    restoreAllExplodeTasks,
+    swapExplodeTasks
+  }
 }

--- a/packages/domains/settings/src/client/useTabStore.test.ts
+++ b/packages/domains/settings/src/client/useTabStore.test.ts
@@ -4,6 +4,22 @@
  */
 
 import { useTabStore } from './useTabStore.js'
+import { _setTrpcClientSingleton } from '@slayzone/transport/client'
+
+// The store persists its view-state slice through tRPC on a 500ms debounce. Once
+// `isLoaded` flips true (which `_loadState` does), any slice change schedules that
+// write — so without a stub the timer fires after the assertions and crashes the
+// run on "tRPC client not ready". Stub it and assert the write instead.
+const settingsWrites: Array<{ key: string; value: string }> = []
+_setTrpcClientSingleton({
+  settings: {
+    set: {
+      mutate: async (input: { key: string; value: string }) => {
+        settingsWrites.push(input)
+      }
+    }
+  }
+} as never)
 
 const store = useTabStore
 
@@ -30,10 +46,7 @@ function test(name: string, fn: () => void) {
 // (tB) that is still open. This is the precondition for the home-icon bug.
 function seedFocusedOnAWithBTaskOpen() {
   store.setState({
-    tabs: [
-      { type: 'home' },
-      { type: 'task', taskId: 'tB', title: 'B-task' }
-    ],
+    tabs: [{ type: 'home' }, { type: 'task', taskId: 'tB', title: 'B-task' }],
     activeTabIndex: 1,
     selectedProjectId: 'pA',
     activeView: 'tabs',
@@ -82,6 +95,55 @@ test('plain switch where last tab was home lands on home', () => {
   store.setState({ projectLastActiveTab: { pB: 'home' } })
   store.getState().selectProject('pB')
   assert(store.getState().activeTabIndex === 0, 'activeTabIndex 0')
+})
+
+// ── explode arrangement persistence ─────────────────────────────────────────
+// The arrangement rides the same `viewState` slice as the rest of the view
+// state, so a renderer reload keeps a layout the user deliberately built.
+
+test('setExplodeArrangement updates order and minimized independently', () => {
+  store.setState({ explodeOrder: ['a', 'b'], explodeMinimized: ['b'] })
+  // Partial write: a drag changes only the order and must not clear the tray.
+  store.getState().setExplodeArrangement({ order: ['b', 'a'] })
+  let s = store.getState()
+  assert(JSON.stringify(s.explodeOrder) === '["b","a"]', `order=${JSON.stringify(s.explodeOrder)}`)
+  assert(JSON.stringify(s.explodeMinimized) === '["b"]', 'minimized untouched by an order write')
+
+  store.getState().setExplodeArrangement({ minimized: [] })
+  s = store.getState()
+  assert(JSON.stringify(s.explodeOrder) === '["b","a"]', 'order untouched by a minimized write')
+  assert(s.explodeMinimized.length === 0, 'minimized cleared')
+})
+
+test('_loadState restores a persisted arrangement', () => {
+  store.getState()._loadState({
+    tabs: [],
+    activeTabIndex: 0,
+    selectedProjectId: '',
+    explodeOrder: ['x', 'y'],
+    explodeMinimized: ['y']
+  })
+  const s = store.getState()
+  assert(JSON.stringify(s.explodeOrder) === '["x","y"]', `order=${JSON.stringify(s.explodeOrder)}`)
+  assert(JSON.stringify(s.explodeMinimized) === '["y"]', 'minimized restored')
+})
+
+test('_loadState rejects malformed arrangement entries', () => {
+  // This JSON lives on disk, so a non-string entry would otherwise flow straight
+  // into layout as an undefined task id.
+  store.getState()._loadState({
+    tabs: [],
+    activeTabIndex: 0,
+    selectedProjectId: '',
+    explodeOrder: ['ok', 42, null, 'fine'] as unknown as string[],
+    explodeMinimized: 'not-an-array' as unknown as string[]
+  })
+  const s = store.getState()
+  assert(
+    JSON.stringify(s.explodeOrder) === '["ok","fine"]',
+    `non-string entries dropped, got ${JSON.stringify(s.explodeOrder)}`
+  )
+  assert(s.explodeMinimized.length === 0, 'non-array falls back to empty')
 })
 
 console.log('Done')

--- a/packages/domains/settings/src/client/useTabStore.ts
+++ b/packages/domains/settings/src/client/useTabStore.ts
@@ -125,6 +125,14 @@ interface TabState {
   // here rather than in TreeView component state so a remount (renderer reload,
   // wake from sleep) doesn't silently reset every project to collapsed.
   treeOpenProjects: Record<string, boolean>
+  // Explode-mode arrangement. Task ids in the order the user dragged them into,
+  // and the ids parked in the header tray. Persisted for the same reason as
+  // `treeOpenProjects`: a renderer reload or a restart would otherwise silently
+  // throw away a layout the user deliberately built, which is the whole point of
+  // being able to arrange it. Reconciled against the open tabs on read, so stale
+  // ids from closed tasks are harmless.
+  explodeOrder: string[]
+  explodeMinimized: string[]
   // Task-detail header layout.
   taskHeaderPanelMode: TaskHeaderPanelMode
   taskHeaderPanelAlign: TaskHeaderAlign
@@ -168,6 +176,7 @@ interface TabState {
   setTreeGroupPinned: (group: boolean) => void
   setTreeShowEmptyGroups: (show: boolean) => void
   setTreeProjectOpen: (projectId: string, open: boolean) => void
+  setExplodeArrangement: (arrangement: { order?: string[]; minimized?: string[] }) => void
   setTaskHeaderPanelMode: (mode: TaskHeaderPanelMode) => void
   setTaskHeaderPanelAlign: (align: TaskHeaderAlign) => void
   setTaskHeaderTitleAlign: (align: TaskHeaderAlign) => void
@@ -215,6 +224,8 @@ interface TabState {
     treeGroupPinned?: boolean
     treeShowEmptyGroups?: boolean
     treeOpenProjects?: Record<string, boolean>
+    explodeOrder?: string[]
+    explodeMinimized?: string[]
     taskHeaderPanelMode?: TaskHeaderPanelMode
     taskHeaderPanelAlign?: TaskHeaderAlign
     taskHeaderTitleAlign?: TaskHeaderAlign
@@ -278,6 +289,8 @@ export const useTabStore = create<TabState>()(
     treeGroupPinned: true,
     treeShowEmptyGroups: false,
     treeOpenProjects: {},
+    explodeOrder: [],
+    explodeMinimized: [],
     taskHeaderPanelMode: 'tabs',
     taskHeaderPanelAlign: 'right',
     taskHeaderTitleAlign: 'left',
@@ -349,6 +362,13 @@ export const useTabStore = create<TabState>()(
 
     setTreeProjectOpen: (projectId, open) =>
       set((s) => ({ treeOpenProjects: { ...s.treeOpenProjects, [projectId]: open } })),
+    // Partial on purpose: a drag changes only the order and a minimize changes only
+    // the tray, so neither has to restate the other and race it.
+    setExplodeArrangement: ({ order, minimized }) =>
+      set((s) => ({
+        explodeOrder: order ?? s.explodeOrder,
+        explodeMinimized: minimized ?? s.explodeMinimized
+      })),
     setTaskHeaderPanelMode: (mode) => set({ taskHeaderPanelMode: mode }),
     setTaskHeaderPanelAlign: (align) => set({ taskHeaderPanelAlign: align }),
     setTaskHeaderTitleAlign: (align) => set({ taskHeaderTitleAlign: align }),
@@ -556,6 +576,14 @@ export const useTabStore = create<TabState>()(
           state.treeOpenProjects && typeof state.treeOpenProjects === 'object'
             ? state.treeOpenProjects
             : {},
+        // Element-level validation: this JSON is on disk and a malformed entry
+        // would flow straight into layout as an undefined task id.
+        explodeOrder: Array.isArray(state.explodeOrder)
+          ? state.explodeOrder.filter((id): id is string => typeof id === 'string')
+          : [],
+        explodeMinimized: Array.isArray(state.explodeMinimized)
+          ? state.explodeMinimized.filter((id): id is string => typeof id === 'string')
+          : [],
         taskHeaderPanelMode: state.taskHeaderPanelMode === 'menu' ? 'menu' : 'tabs',
         taskHeaderPanelAlign: state.taskHeaderPanelAlign === 'left' ? 'left' : 'right',
         taskHeaderTitleAlign: state.taskHeaderTitleAlign === 'right' ? 'right' : 'left',
@@ -659,6 +687,8 @@ useTabStore.subscribe(
     treeGroupPinned: state.treeGroupPinned,
     treeShowEmptyGroups: state.treeShowEmptyGroups,
     treeOpenProjects: state.treeOpenProjects,
+    explodeOrder: state.explodeOrder,
+    explodeMinimized: state.explodeMinimized,
     taskHeaderPanelMode: state.taskHeaderPanelMode,
     taskHeaderPanelAlign: state.taskHeaderPanelAlign,
     taskHeaderTitleAlign: state.taskHeaderTitleAlign,
@@ -738,8 +768,7 @@ useTabStore.subscribe(
         // idempotent per-window and each hub only tracks its own projects.
         const defaultClient = getTrpcClient()
         for (const [hubId, counts] of countsByHub) {
-          const client =
-            hubId && getHubClient(hubId) ? getHubClient(hubId)!.client : defaultClient
+          const client = hubId && getHubClient(hubId) ? getHubClient(hubId)!.client : defaultClient
           client.pty.warmSetProjectTabCounts.mutate({ counts }).catch(() => {})
         }
         // No open task tabs at all → clear the default hub's counts (preserves the

--- a/packages/domains/task/src/client/TaskDetailPage.tsx
+++ b/packages/domains/task/src/client/TaskDetailPage.tsx
@@ -1673,9 +1673,45 @@ export const TaskDetailPage = React.memo(function TaskDetailPage({
                 </Popover>
               )
             })()}
-          <span className="text-xs font-medium truncate flex-1">
-            {task.is_temporary ? 'Temporary task' : task.title}
-          </span>
+          {/* Double-click to rename, mirroring the tab bar. Explode mode sets
+              `hideTabs`, so this compact header is the ONLY place the title is
+              shown — without this a task simply cannot be renamed there.
+              Double-click rather than the full header's single-click: this strip
+              is small and clicking it is how you focus the cell, so single-click
+              editing would fire constantly by accident. */}
+          {editingTitle && !task.is_temporary ? (
+            <input
+              ref={titleInputRef}
+              value={titleValue}
+              onChange={(e) => setTitleValue(e.target.value)}
+              onBlur={handleTitleSave}
+              onKeyDown={handleTitleKeyDown}
+              onClick={(e) => e.stopPropagation()}
+              onDoubleClick={(e) => e.stopPropagation()}
+              className="text-xs font-medium flex-1 min-w-0 bg-transparent border-none outline-none ring-1 ring-ring rounded px-1"
+              aria-label="Task title"
+              data-testid="compact-title-input"
+            />
+          ) : (
+            <span
+              className={cn(
+                'text-xs font-medium truncate flex-1',
+                !task.is_temporary && 'cursor-text'
+              )}
+              onDoubleClick={
+                task.is_temporary
+                  ? undefined
+                  : (e) => {
+                      e.stopPropagation()
+                      setEditingTitle(true)
+                    }
+              }
+              title={task.is_temporary ? undefined : 'Double-click to rename'}
+              data-testid="compact-title"
+            >
+              {task.is_temporary ? 'Temporary task' : task.title}
+            </span>
+          )}
           {!task.is_temporary && (
             <Popover open={priorityPopoverOpen} onOpenChange={setPriorityPopoverOpen}>
               <PopoverTrigger asChild>

--- a/packages/shared/transport/src/client/index.ts
+++ b/packages/shared/transport/src/client/index.ts
@@ -8,6 +8,10 @@ export {
   getHubClient,
   listHubClients,
   _resetHubClients,
+  // Test seam, exported for the same reason as `_resetHubClients`: unit tests of
+  // stores that persist through tRPC need a stub, or their debounced write fires
+  // after the assertions and crashes the run on "tRPC client not ready".
+  _setTrpcClientSingleton,
   type CreateTrpcClientOpts,
   type TrpcVanillaClient,
   type HubWsClient,


### PR DESCRIPTION
# feat: explode mode layout control — repack, minimize, swap

Explode mode is great for watching several agents at once, but it offers no control over the grid. Three changes, each addressing something that bit me using it daily.

## 1. Repack — no dead cells

`repeat(cols, 1fr) x repeat(rows, 1fr)` wastes space on uneven counts. Three terminals in two columns puts the third at half height beside an **empty cell**:

```
before                        after
┌────────┬────────┐          ┌────────┬────────┐
│   1    │   2    │          │   1    │        │
├────────┼────────┤          ├────────┤   3    │
│   3    │ (dead) │          │   2    │        │
└────────┴────────┘          └────────┴────────┘
```

Cells now get explicit pixel rects from a pure layout function, packed column-major so the odd one out owns a column at full height. `3/2 → [2,1]`, `5/3 → [2,2,1]`, `4/2 → [2,2]` (already even, unchanged).

**Why rects and not grid tracks.** The cells are one flat `tabs.map` shared by explode and normal mode (normal mode already positions them `absolute inset-0`). Wrapping them in per-column elements for explode mode would change the React tree between modes and **remount every terminal — losing xterm scrollback on every toggle**. Rects also express "one cell fixed, siblings absorb the rest", which mixed `auto`/`1fr` tracks cannot do per-column.

Rects snap to whole pixels, rounding **edges** rather than sizes so neighbours still tile exactly. This is not cosmetic: xterm derives its row count from the measured container, so a fractional height can flip between N and N+1 rows on sub-pixel jitter, and each flip is a real `fit()`, a SIGWINCH to the pty and a WebGL atlas re-raster. `ensureFit` is idempotent on a *stable* geometry, but an oscillating one defeats it.

## 2. Minimize — to a header tray

A minimized terminal leaves the grid entirely and parks beside the "N tasks" label (explode is the one layout with spare header room). Survivors repack over it, so minimizing actually buys space rather than leaving a collapsed strip still holding a row.

It stays **mounted and inert, never unmounted** — it keeps running with its scrollback, which is the point of minimizing rather than closing. Focus is also pushed off a minimized cell, or shortcuts would route to a terminal the user cannot see.

## 3. Swap — drag one cell onto another

A hover-revealed grip exchanges exactly two positions. Swap, not splice: a splice cascade-shifts the tail, which reads as "everything moved" when one trade was asked for.

Native DnD with a custom mime rather than `@dnd-kit` (which is already a dependency): the layout is custom rects, not a DOM-ordered sortable list, and the mime lets file/text drags fall through to the terminal that should handle them.

Both handlers sit on the grid in the **capture** phase. `Terminal.tsx` attaches a `dragover` listener that calls `stopPropagation()` unconditionally (it owns file-drop-to-paste-path), so a bubbling handler on the cell never fires once the pointer is over terminal content — which is most of a cell, and effectively all of a full-height one. That made swaps appear to work only between same-sized cells.

## Persistence

Arrangement (order + tray) rides the tab store's `viewState` slice, alongside `treeOpenProjects` and the other view state that lives there for exactly this reason — a reload would otherwise throw away a layout the user deliberately built. `_loadState` validates element-by-element, since that JSON is on disk and a malformed entry would flow into layout as an undefined task id. Stale ids from closed tasks are handled by the existing reconcile-against-open-tabs on read.

## Verification

- `explodeLayout.test.ts` — **65 checks**: packing, the 3-in-2-columns case, exact tiling, whole-pixel rects at awkward sizes (1001x601), swap semantics, order reconciliation.
- `useTabStore.test.ts` — 3 new cases for partial arrangement writes, restore, and malformed input; all 7 pass.
- `pnpm lint:theme`, `pnpm lint:server-boundary`, `pnpm typecheck`, `pnpm --filter @slayzone/cli build`, `pnpm build` — all clean (i.e. the full `check` job).
- Used daily in a local build while developing it; the two bugs above were found that way.

## Notes

- `_setTrpcClientSingleton` is exported from the transport client barrel, for the same reason `_resetHubClients` already is: the store persists on a 500ms debounce, so a unit test that flips `isLoaded` schedules a tRPC write that fires after the assertions and crashes the run.
- The large `App.tsx` hunk is mostly re-indentation — the explode grid block was previously indented one level shallow, and editing it brought the subtree into line.
- **Known cosmetic issue:** xterm's scrollbar can look slightly off, because cell heights are whole pixels but not multiples of the terminal row height, leaving a few pixels below the last row while the scrollbar spans the container. This predates the change (fractional track heights were worse); a real fix means snapping to row multiples, which the layout cannot do without knowing each cell's non-terminal chrome.

Happy to split this into separate PRs (repack / minimize / swap) if you'd prefer to take them independently, or to adjust the interaction design — the affordances are deliberately small and hover-only, but that is easy to change.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds persistent explode-mode layout controls while preserving mounted terminal sessions.
- Replaces CSS grid tracks with explicit, integer-pixel cell rectangles and column-major packing.
- Adds terminal minimization to a header tray and drag-to-swap ordering.
- Persists arrangement state and reconciles it against currently open task tabs.
- Deduplicates restored ordering before layout, resolving the previously reported orphan-cell defect.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; persisted duplicate order entries are deduplicated before reaching the layout engine.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/domains/app-shell/src/client/explodeLayout.ts | Implements deterministic packing, swaps, and order reconciliation; duplicate IDs are removed before layout. |
| packages/domains/app-shell/src/client/useExplodeMode.ts | Reconciles persisted arrangement with open tabs and manages minimized, focused, swapped, and measured explode state. |
| packages/apps/app/src/renderer/src/App.tsx | Applies explicit cell rectangles and adds capture-phase swapping and mounted-but-inert minimized terminals. |
| packages/domains/settings/src/client/useTabStore.ts | Persists and validates explode ordering and minimized-task state. |
| packages/domains/app-shell/src/client/explodeLayout.test.ts | Covers packing geometry, integer tiling, swaps, reconciliation, and duplicate-order regression cases. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Store[Persisted explode arrangement] --> Reconcile[Reconcile with open tasks and deduplicate]
  Reconcile --> Visible[Visible task IDs]
  Reconcile --> Tray[Minimized task IDs]
  Visible --> Layout[Compute integer-pixel rectangles]
  Layout --> Grid[Render mounted terminal cells]
  Tray --> Header[Render minimized tray]
  Grid -->|drag swap| Store
  Header -->|restore| Store
```
</details>

<sub>Reviews (3): Last reviewed commit: ["feat(explode): allow renaming a task fro..."](https://github.com/debuglebowski/slayzone/commit/2a729e4ed987fc723029e4cd80baafee92bfcacb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51412609)</sub>

<!-- /greptile_comment -->